### PR TITLE
Migrate to charcoal-translator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "locomotivemtl/charcoal-cms",
     "type": "library",
     "description": "Charcoal CMS (Content Management System) Module",
-    "keywords": ["charcoal", "cms"],
+    "keywords": [ "charcoal", "cms" ],
     "homepage": "https://charcoal.locomotive.ca",
     "license": "MIT",
     "authors": [
@@ -15,32 +15,33 @@
             "homepage": "https://locomotive.ca"
         }
     ],
+    "minimum-stability":"dev",
+    "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1.x-dev"
+            "dev-master": "0.2.x-dev"
         }
     },
-    "minimum-stability":"dev",
     "require": {
         "php": ">=5.6.0",
         "psr/http-message": "^1.0",
-        "locomotivemtl/charcoal-app": "~0.2",
-        "locomotivemtl/charcoal-core": "~0.1",
-        "locomotivemtl/charcoal-factory": "~0.3",
+        "locomotivemtl/charcoal-app": "~0.4",
+        "locomotivemtl/charcoal-core": "~0.2",
+        "locomotivemtl/charcoal-factory": "~0.4",
         "locomotivemtl/charcoal-object": "~0.1",
-        "locomotivemtl/charcoal-translation": "~0.1"
+        "locomotivemtl/charcoal-translator": "~0.1"
     },
     "require-dev": {
         "psr/log": "^1.0",
         "phpunit/phpunit": "^4.8",
+        "mockery/mockery": "^0.9.6",
         "squizlabs/php_codesniffer": "^2.4",
         "satooshi/php-coveralls": "~1.0.1",
         "cache/void-adapter": "^0.3.0"
     },
     "autoload": {
         "psr-4": {
-            "Charcoal\\Cms\\": "src/Charcoal/Cms",
-            "Charcoal\\Property\\": "src/Charcoal/Property"
+            "Charcoal\\": "src/Charcoal"
         }
     },
     "autoload-dev": {

--- a/src/Charcoal/Cms/AbstractDocument.php
+++ b/src/Charcoal/Cms/AbstractDocument.php
@@ -2,15 +2,15 @@
 
 namespace Charcoal\Cms;
 
-// Module `charcoal-object` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategorizableInterface;
 use Charcoal\Object\CategorizableTrait;
 
-// Module `charcoal-translation` dependencies
-use Charcoal\Translation\TranslationString;
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
 
-// Intra-module `charcoal-cms` depdencies
+// From 'charcoal-cms'
 use Charcoal\Cms\DocumentInterface;
 
 /**
@@ -23,7 +23,7 @@ abstract class AbstractDocument extends Content implements
     use CategorizableTrait;
 
     /**
-     * @var TranslationString $name
+     * @var Translation|string|null $name
      */
     private $name;
 
@@ -43,17 +43,17 @@ abstract class AbstractDocument extends Content implements
     private $baseUrl;
 
     /**
-     * @param mixed $name The document name.
-     * @return DocumentInterface Chainable
+     * @param  mixed $name The document name.
+     * @return self
      */
     public function setName($name)
     {
-        $this->name = new TranslationString($name);
+        $this->name = $this->translator()->translation($name);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function name()
     {
@@ -61,8 +61,8 @@ abstract class AbstractDocument extends Content implements
     }
 
     /**
-     * @param string $file The file relative path / url.
-     * @return DocumentInterface Chainable
+     * @param  string $file The file relative path / url.
+     * @return self
      */
     public function setFile($file)
     {
@@ -79,8 +79,8 @@ abstract class AbstractDocument extends Content implements
     }
 
     /**
-     * @param string $path The document base path.
-     * @return DocumentInterface Chainable
+     * @param  string $path The document base path.
+     * @return self
      */
     public function setBasePath($path)
     {
@@ -102,8 +102,8 @@ abstract class AbstractDocument extends Content implements
     }
 
     /**
-     * @param string $url The document base URL.
-     * @return DocumentInterface Chainable
+     * @param  string $url The document base URL.
+     * @return self
      */
     public function setBaseUrl($url)
     {

--- a/src/Charcoal/Cms/AbstractEvent.php
+++ b/src/Charcoal/Cms/AbstractEvent.php
@@ -4,14 +4,13 @@ namespace Charcoal\Cms;
 
 use DateTime;
 use DateTimeInterface;
-use Exception;
 use InvalidArgumentException;
 
-// PSR-7 (HTTP messaging) dependencies
+// From PSR-7
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-// Module `charcoal-object` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategorizableInterface;
 use Charcoal\Object\CategorizableTrait;
@@ -20,10 +19,10 @@ use Charcoal\Object\PublishableTrait;
 use Charcoal\Object\RoutableInterface;
 use Charcoal\Object\RoutableTrait;
 
-// Module `charcoal-translation` depdencies
-use Charcoal\Translation\TranslationString;
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
 
-// Intra-module (`charcoal-cms`) dependencies
+// From 'charcoal-cms'
 use Charcoal\Cms\MetatagInterface;
 use Charcoal\Cms\SearchableInterface;
 use Charcoal\Cms\TemplateableInterface;
@@ -48,53 +47,53 @@ abstract class AbstractEvent extends Content implements
     use TemplateableTrait;
 
     /**
-     * @var TranslationString $title
+     * @var Translation|string|null
      */
     private $title;
 
     /**
-     * @var TranslationString $subtitle
+     * @var Translation|string|null
      */
     private $subtitle;
 
     /**
-     * @var TranslationString $summary
+     * @var Translation|string|null
      */
     private $summary;
 
     /**
-     * @var TranslationString $content
+     * @var Translation|string|null
      */
     private $content;
 
     /**
-     * @var TranslationString $image
+     * @var Translation|string|null
      */
     private $image;
 
     /**
-     * @var DateTime $startDate
+     * @var DateTimeInterface|null
      */
     private $startDate;
 
     /**
-     * @var DateTime $startDate
+     * @var DateTimeInterface|null
      */
     private $endDate;
 
     /**
-     * @param mixed $title The event title (localized).
-     * @return EventInterface Chainable
+     * @param  mixed $title The event title (localized).
+     * @return self
      */
     public function setTitle($title)
     {
-        $this->title = new TranslationString($title);
+        $this->title = $this->translator()->translation($title);
 
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function title()
     {
@@ -102,18 +101,18 @@ abstract class AbstractEvent extends Content implements
     }
 
     /**
-     * @param mixed $subtitle The event subtitle (localized).
-     * @return EventInterface Chainable
+     * @param  mixed $subtitle The event subtitle (localized).
+     * @return self
      */
     public function setSubtitle($subtitle)
     {
-        $this->subtitle = new TranslationString($subtitle);
+        $this->subtitle = $this->translator()->translation($subtitle);
 
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function subtitle()
     {
@@ -121,18 +120,18 @@ abstract class AbstractEvent extends Content implements
     }
 
     /**
-     * @param mixed $summary The news summary (localized).
-     * @return EventInterface Chainable
+     * @param  mixed $summary The news summary (localized).
+     * @return self
      */
     public function setSummary($summary)
     {
-        $this->summary = new TranslationString($summary);
+        $this->summary = $this->translator()->translation($summary);
 
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function summary()
     {
@@ -140,18 +139,18 @@ abstract class AbstractEvent extends Content implements
     }
 
     /**
-     * @param mixed $content The event content (localized).
-     * @return EventInterface Chainable
+     * @param  mixed $content The event content (localized).
+     * @return self
      */
     public function setContent($content)
     {
-        $this->content = new TranslationString($content);
+        $this->content = $this->translator()->translation($content);
 
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function content()
     {
@@ -159,18 +158,18 @@ abstract class AbstractEvent extends Content implements
     }
 
     /**
-     * @param mixed $image The section main image (localized).
-     * @return EventInterface Chainable
+     * @param  mixed $image The section main image (localized).
+     * @return self
      */
     public function setImage($image)
     {
-        $this->image = new TranslationString($image);
+        $this->image = $this->translator()->translation($image);
 
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function image()
     {
@@ -178,9 +177,9 @@ abstract class AbstractEvent extends Content implements
     }
 
     /**
-     * @param string|DateTime $startDate Event starting date.
+     * @param  string|DateTimeInterface $startDate Event starting date.
      * @throws InvalidArgumentException If the timestamp is invalid.
-     * @return EventInterface Chainable
+     * @return self
      */
     public function setStartDate($startDate)
     {
@@ -203,7 +202,7 @@ abstract class AbstractEvent extends Content implements
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTimeInterface|null
      */
     public function startDate()
     {
@@ -211,9 +210,9 @@ abstract class AbstractEvent extends Content implements
     }
 
     /**
-     * @param string|DateTime $endDate Event end date.
+     * @param  string|DateTimeInterface $endDate Event end date.
      * @throws InvalidArgumentException If the timestamp is invalid.
-     * @return EventInterface Chainable
+     * @return self
      */
     public function setEndDate($endDate)
     {
@@ -236,7 +235,7 @@ abstract class AbstractEvent extends Content implements
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTimeInterface|null
      */
     public function endDate()
     {
@@ -246,8 +245,8 @@ abstract class AbstractEvent extends Content implements
     /**
      * MetatagTrait > canonical_url
      *
-     * @return string
      * @todo
+     * @return string
      */
     public function canonicalUrl()
     {
@@ -255,7 +254,7 @@ abstract class AbstractEvent extends Content implements
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaTitle()
     {
@@ -263,27 +262,25 @@ abstract class AbstractEvent extends Content implements
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaDescription()
     {
-        $content = $this->content();
+        $content = $this->translator()->translation($this->content());
+        if ($content instanceof Translation) {
+            $desc = [];
+            foreach ($content->data() as $lang => $text) {
+                $desc[$lang] = strip_tags($text);
+            }
 
-        if (!($content instanceof TranslationString)) {
-            $content = new TranslationString($content);
+            return $this->translator()->translation($desc);
         }
 
-        $out = [];
-        foreach ($content->all() as $lang => $text) {
-            $out[$lang] = strip_tags($text);
-        }
-
-        // Don't affect the content's content.
-        return new TranslationString($out);
+        return null;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaImage()
     {
@@ -306,7 +303,7 @@ abstract class AbstractEvent extends Content implements
     /**
      * {@inheritdoc}
      *
-     * @param array $properties Optional properties to update.
+     * @param  array $properties Optional properties to update.
      * @return boolean
      */
     public function preUpdate(array $properties = null)

--- a/src/Charcoal/Cms/AbstractFaq.php
+++ b/src/Charcoal/Cms/AbstractFaq.php
@@ -2,17 +2,17 @@
 
 namespace Charcoal\Cms;
 
-// Module `charcoal-translation` dependency
-use Charcoal\Translation\TranslationString;
-
-// Module `charcoal-object` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategorizableInterface;
 use Charcoal\Object\CategorizableTrait;
 use Charcoal\Object\PublishableInterface;
 use Charcoal\Object\PublishableTrait;
 
-// Local namespace (`charcoal-cms`) dependencies
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
+// From 'charcoal-cms'
 use Charcoal\Cms\FaqInterface;
 use Charcoal\Cms\MetatagInterface;
 use Charcoal\Cms\SearchableInterface;
@@ -32,28 +32,29 @@ abstract class AbstractFaq extends Content implements
     use SearchableTrait;
 
     /**
-     * The question, or "title", of this entry
-     * @var TranslationString $question
+     * The question, or "title", of this entry.
+     *
+     * @var Translation|string|null
      */
     private $question;
 
     /**
-     * @var TranslationString $answer
+     * @var Translation|string|null
      */
     private $answer;
 
     /**
-     * @param mixed $question The question (localized).
-     * @return FaqInterface Chainable
+     * @param  mixed $question The question (localized).
+     * @return self
      */
     public function setQuestion($question)
     {
-        $this->question = new TranslationString($question);
+        $this->question = $this->translator()->translation($question);
         return $this;
     }
 
     /**
-     * @return TranslationString|null
+     * @return Translation|string|null
      */
     public function question()
     {
@@ -61,17 +62,17 @@ abstract class AbstractFaq extends Content implements
     }
 
     /**
-     * @param mixed $answer The answer (localized).
-     * @return FaqInterface Chainable
+     * @param  mixed $answer The answer (localized).
+     * @return self
      */
     public function setAnswer($answer)
     {
-        $this->answer = new TranslationString($answer);
+        $this->answer = $this->translator()->translation($answer);
         return $this;
     }
 
     /**
-     * @return TranslationString|null
+     * @return Translation|string|null
      */
     public function answer()
     {

--- a/src/Charcoal/Cms/AbstractImage.php
+++ b/src/Charcoal/Cms/AbstractImage.php
@@ -2,6 +2,9 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-cms'
+use Charcoal\Cms\AbstractDocument;
+
 /**
  * Base Image class.
  */

--- a/src/Charcoal/Cms/AbstractNews.php
+++ b/src/Charcoal/Cms/AbstractNews.php
@@ -6,13 +6,11 @@ use DateTime;
 use DateTimeInterface;
 use InvalidArgumentException;
 
+// From PSR-7
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-// Dependencies from `charcoal-translation`
-use Charcoal\Translation\TranslationString;
-
-// Dependencies from `charcoal-object`
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategorizableInterface;
 use Charcoal\Object\CategorizableTrait;
@@ -21,7 +19,10 @@ use Charcoal\Object\PublishableTrait;
 use Charcoal\Object\RoutableInterface;
 use Charcoal\Object\RoutableTrait;
 
-// Intra-module (`charcoal-cms`) dependencies
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
+// From 'charcoal-cms'
 use Charcoal\Cms\MetatagInterface;
 use Charcoal\Cms\NewsInterface;
 use Charcoal\Cms\SearchableInterface;
@@ -48,53 +49,53 @@ abstract class AbstractNews extends Content implements
     use TemplateableTrait;
 
     /**
-     * @var TranslationString $title
+     * @var Translation|string|null
      */
     private $title;
 
     /**
-     * @var TranslationString $title
+     * @var Translation|string|null
      */
     private $subtitle;
 
     /**
-     * @var TranslationString $title
+     * @var Translation|string|null
      */
     private $summary;
 
     /**
-     * @var TranslationString $content
+     * @var Translation|string|null
      */
     private $content;
 
     /**
-     * @var TranslationString $image
+     * @var Translation|string|null
      */
     private $image;
 
     /**
-     * @var DateTime $newsDate
+     * @var DateTimeInterface|null
      */
     private $newsDate;
 
     /**
-     * @var TranslationString $infoUrl
+     * @var Translation|string|null
      */
     private $infoUrl;
 
     /**
-     * @param mixed $title The news title (localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $title The news title (localized).
+     * @return self
      */
     public function setTitle($title)
     {
-        $this->title = new TranslationString($title);
+        $this->title = $this->translator()->translation($title);
 
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function title()
     {
@@ -102,18 +103,18 @@ abstract class AbstractNews extends Content implements
     }
 
     /**
-     * @param mixed $subtitle The news subtitle (localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $subtitle The news subtitle (localized).
+     * @return self
      */
     public function setSubtitle($subtitle)
     {
-        $this->subtitle = new TranslationString($subtitle);
+        $this->subtitle = $this->translator()->translation($subtitle);
 
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function subtitle()
     {
@@ -121,18 +122,18 @@ abstract class AbstractNews extends Content implements
     }
 
     /**
-     * @param mixed $summary The news summary (localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $summary The news summary (localized).
+     * @return self
      */
     public function setSummary($summary)
     {
-        $this->summary = new TranslationString($summary);
+        $this->summary = $this->translator()->translation($summary);
 
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function summary()
     {
@@ -140,18 +141,18 @@ abstract class AbstractNews extends Content implements
     }
 
     /**
-     * @param mixed $content The news content (localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $content The news content (localized).
+     * @return self
      */
     public function setContent($content)
     {
-        $this->content = new TranslationString($content);
+        $this->content = $this->translator()->translation($content);
 
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function content()
     {
@@ -159,18 +160,18 @@ abstract class AbstractNews extends Content implements
     }
 
     /**
-     * @param mixed $image The section main image (localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $image The section main image (localized).
+     * @return self
      */
     public function setImage($image)
     {
-        $this->image = new TranslationString($image);
+        $this->image = $this->translator()->translation($image);
 
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function image()
     {
@@ -178,9 +179,9 @@ abstract class AbstractNews extends Content implements
     }
 
     /**
-     * @param mixed $newsDate The news date.
+     * @param  string|DateTimeInterface $newsDate The news date.
      * @throws InvalidArgumentException If the timestamp is invalid.
-     * @return NewsInterface Chainable
+     * @return self
      */
     public function setNewsDate($newsDate)
     {
@@ -203,7 +204,7 @@ abstract class AbstractNews extends Content implements
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTimeInterface|null
      */
     public function newsDate()
     {
@@ -211,18 +212,18 @@ abstract class AbstractNews extends Content implements
     }
 
     /**
-     * @param mixed $url The info URL (news source or where to find more information; localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $url The info URL (news source or where to find more information; localized).
+     * @return self
      */
     public function setInfoUrl($url)
     {
-        $this->infoUrl = new TranslationString($url);
+        $this->infoUrl = $this->translator()->translation($url);
 
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function infoUrl()
     {
@@ -232,8 +233,8 @@ abstract class AbstractNews extends Content implements
     /**
      * MetatagTrait > canonical_url
      *
-     * @return string
      * @todo
+     * @return string
      */
     public function canonicalUrl()
     {
@@ -241,7 +242,7 @@ abstract class AbstractNews extends Content implements
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaTitle()
     {
@@ -249,26 +250,24 @@ abstract class AbstractNews extends Content implements
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaDescription()
     {
-        $content = $this->content();
+        $content = $this->translator()->translation($this->content());
+        if ($content instanceof Translation) {
+            $desc = [];
+            foreach ($content->data() as $lang => $text) {
+                $desc[$lang] = strip_tags($text);
+            }
 
-        if (!($content instanceof TranslationString)) {
-            $content = new TranslationString($content);
+            return $this->translator()->translation($desc);
         }
 
-        $out = [];
-        foreach ($content->all() as $lang => $text) {
-            $out[$lang] = strip_tags($text);
-        }
-
-        // Don't affect the content's content.
-        return new TranslationString($out);
+        return null;
     }
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaImage()
     {

--- a/src/Charcoal/Cms/AbstractSection.php
+++ b/src/Charcoal/Cms/AbstractSection.php
@@ -4,22 +4,21 @@ namespace Charcoal\Cms;
 
 use InvalidArgumentException;
 
-// Module `charcoal-core` dependencies
+// From 'charcoal-core'
 use Charcoal\Model\Collection;
-
-// Module `charcoal-translation` dependencies
-use Charcoal\Translation\TranslationString;
-
 use Charcoal\Loader\CollectionLoader;
 
-// Module `charcoal-base` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\HierarchicalInterface;
 use Charcoal\Object\HierarchicalTrait;
 use Charcoal\Object\RoutableInterface;
 use Charcoal\Object\RoutableTrait;
 
-// Intra-module (`charcoal-cms`) dependencies
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
+// From 'charcoal-cms'
 use Charcoal\Cms\MetatagInterface;
 use Charcoal\Cms\SearchableInterface;
 use Charcoal\Cms\SectionInterface;
@@ -66,25 +65,27 @@ abstract class AbstractSection extends Content implements
     const DEFAULT_TYPE  = self::TYPE_CONTENT;
 
     /**
-     * @var string $sectionType
+     * @var string
      */
     private $sectionType = self::DEFAULT_TYPE;
 
     /**
-     * @var TranslationString $title
+     * @var Translation|string|null
      */
     private $title;
+
     /**
-     * @var TranslationString $subtitle
+     * @var Translation|string|null
      */
     private $subtitle;
+
     /**
-     * @var TranslationString $content
+     * @var Translation|string|null
      */
     private $content;
 
     /**
-     * @var TranslationString $image
+     * @var Translation|string|null
      */
     private $image;
 
@@ -96,9 +97,9 @@ abstract class AbstractSection extends Content implements
     /**
      * Set the section's type.
      *
-     * @param string $type The section type.
+     * @param  string $type The section type.
      * @throws InvalidArgumentException If the section type is not a string or not a valid section type.
-     * @return SectionInterface Chainable
+     * @return self
      */
     public function setSectionType($type)
     {
@@ -145,17 +146,17 @@ abstract class AbstractSection extends Content implements
     }
 
     /**
-     * @param mixed $title The section title (localized).
-     * @return TranslationString
+     * @param  mixed $title The section title (localized).
+     * @return self
      */
     public function setTitle($title)
     {
-        $this->title = new TranslationString($title);
+        $this->title = $this->translator()->translation($title);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function title()
     {
@@ -163,17 +164,17 @@ abstract class AbstractSection extends Content implements
     }
 
     /**
-     * @param mixed $subtitle The section subtitle (localized).
-     * @return Section Chainable
+     * @param  mixed $subtitle The section subtitle (localized).
+     * @return self
      */
     public function setSubtitle($subtitle)
     {
-        $this->subtitle = new TranslationString($subtitle);
+        $this->subtitle = $this->translator()->translation($subtitle);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function subtitle()
     {
@@ -181,17 +182,17 @@ abstract class AbstractSection extends Content implements
     }
 
     /**
-     * @param mixed $content The section content (localized).
-     * @return Section Chainable
+     * @param  mixed $content The section content (localized).
+     * @return self
      */
     public function setContent($content)
     {
-        $this->content = new TranslationString($content);
+        $this->content = $this->translator()->translation($content);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function content()
     {
@@ -199,17 +200,17 @@ abstract class AbstractSection extends Content implements
     }
 
     /**
-     * @param mixed $image The section main image (localized).
-     * @return Section Chainable
+     * @param  mixed $image The section main image (localized).
+     * @return self
      */
     public function setImage($image)
     {
-        $this->image = new TranslationString($image);
+        $this->image = $this->translator()->translation($image);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function image()
     {
@@ -217,7 +218,7 @@ abstract class AbstractSection extends Content implements
     }
 
     /**
-     * @param string $type Optional type.
+     * @param  string $type Optional type.
      * @return array
      */
     public function attachments($type = null)
@@ -245,7 +246,7 @@ abstract class AbstractSection extends Content implements
     /**
      * HierarchicalTrait > loadChildren
      *
-     * @return Co
+     * @return Collection
      */
     public function loadChildren()
     {
@@ -273,8 +274,8 @@ abstract class AbstractSection extends Content implements
     /**
      * MetatagTrait > canonicalUrl
      *
-     * @return string
      * @todo
+     * @return string
      */
     public function canonicalUrl()
     {
@@ -282,7 +283,7 @@ abstract class AbstractSection extends Content implements
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaTitle()
     {
@@ -290,27 +291,25 @@ abstract class AbstractSection extends Content implements
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaDescription()
     {
-        $content = $this->content();
+        $content = $this->translator()->translation($this->content());
+        if ($content instanceof Translation) {
+            $desc = [];
+            foreach ($content->data() as $lang => $text) {
+                $desc[$lang] = strip_tags($text);
+            }
 
-        if (!($content instanceof TranslationString)) {
-            $content = new TranslationString($content);
+            return $this->translator()->translation($desc);
         }
 
-        $out = [];
-        foreach ($content->all() as $lang => $text) {
-            $out[$lang] = strip_tags($text);
-        }
-
-        // Don't affect the content's content.
-        return new TranslationString($out);
+        return null;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaImage()
     {

--- a/src/Charcoal/Cms/AbstractText.php
+++ b/src/Charcoal/Cms/AbstractText.php
@@ -2,17 +2,17 @@
 
 namespace Charcoal\Cms;
 
-// Dependencies from `charcoal-translation`
-use Charcoal\Translation\TranslationString;
-
-// Module `charcoal-base` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategorizableInterface;
 use Charcoal\Object\CategorizableTrait;
 use Charcoal\Object\PublishableInterface;
 use Charcoal\Object\PublishableTrait;
 
-// Intra-module (`charcoal-cms`) dependencies
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
+// From 'charcoal-cms'
 use Charcoal\Cms\SearchableInterface;
 use Charcoal\Cms\SearchableTrait;
 use Charcoal\Cms\TextInterface;
@@ -31,32 +31,32 @@ abstract class AbstractText extends Content implements
     use SearchableTrait;
 
     /**
-     * @var TranslationString $title
+     * @var Translation|string|null
      */
     private $title;
 
     /**
-     * @var TranslationString $title
+     * @var Translation|string|null
      */
     private $subtitle;
 
     /**
-     * @var TranslationString $content
+     * @var Translation|string|null
      */
     private $content;
 
     /**
-     * @param mixed $title The news title (localized).
-     * @return TranslationString
+     * @param  mixed $title The news title (localized).
+     * @return TextInterface
      */
     public function setTitle($title)
     {
-        $this->title = new TranslationString($title);
+        $this->title = $this->translator()->translation($title);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function title()
     {
@@ -64,17 +64,17 @@ abstract class AbstractText extends Content implements
     }
 
     /**
-     * @param mixed $subtitle The news subtitle (localized).
-     * @return Event Chainable
+     * @param  mixed $subtitle The news subtitle (localized).
+     * @return self
      */
     public function setSubtitle($subtitle)
     {
-        $this->subtitle = new TranslationString($subtitle);
+        $this->subtitle = $this->translator()->translation($subtitle);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function subtitle()
     {
@@ -82,17 +82,17 @@ abstract class AbstractText extends Content implements
     }
 
     /**
-     * @param mixed $content The news content (localized).
-     * @return Event Chainable
+     * @param  mixed $content The news content (localized).
+     * @return self
      */
     public function setContent($content)
     {
-        $this->content = new TranslationString($content);
+        $this->content = $this->translator()->translation($content);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function content()
     {

--- a/src/Charcoal/Cms/AbstractVideo.php
+++ b/src/Charcoal/Cms/AbstractVideo.php
@@ -2,6 +2,7 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\AbstractDocument;
 
 /**

--- a/src/Charcoal/Cms/Document.php
+++ b/src/Charcoal/Cms/Document.php
@@ -2,6 +2,7 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\AbstractDocument;
 use Charcoal\Cms\DocumentCategory;
 

--- a/src/Charcoal/Cms/DocumentCategory.php
+++ b/src/Charcoal/Cms/DocumentCategory.php
@@ -2,16 +2,16 @@
 
 namespace Charcoal\Cms;
 
-// Module `charcoal-base` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategoryInterface;
 use Charcoal\Object\CategoryTrait;
 
-// Local namespace (`charcooal-cms) dependency
+// From 'charcoal-cms'
 use Charcoal\Cms\Document;
 
 /**
- * Document category.
+ * Document Category
  */
 final class DocumentCategory extends Content implements CategoryInterface
 {
@@ -28,7 +28,7 @@ final class DocumentCategory extends Content implements CategoryInterface
     }
 
     /**
-     * @return Collection
+     * @return \Charcoal\Model\Collection|array
      */
     public function loadCategoryItems()
     {

--- a/src/Charcoal/Cms/DocumentInterface.php
+++ b/src/Charcoal/Cms/DocumentInterface.php
@@ -2,25 +2,28 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
 /**
  *
  */
 interface DocumentInterface
 {
     /**
-     * @param mixed $name The document name (localized).
-     * @return DocumentInterface Chainable
+     * @param  mixed $name The document name (localized).
+     * @return self
      */
     public function setName($name);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function name();
 
     /**
-     * @param string $file The file relative path / url (localized).
-     * @return DocumentInterface Chainable
+     * @param  string $file The file relative path / url (localized).
+     * @return self
      */
     public function setFile($file);
 

--- a/src/Charcoal/Cms/Event.php
+++ b/src/Charcoal/Cms/Event.php
@@ -2,11 +2,12 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\AbstractEvent;
 use Charcoal\Cms\EventCategory;
 
 /**
- * CMS Event.
+ * CMS Event
  */
 final class Event extends AbstractEvent
 {
@@ -23,8 +24,8 @@ final class Event extends AbstractEvent
     /**
      * MetatagTrait > canonical_url
      *
-     * @return string
      * @todo
+     * @return string
      */
     public function canonicalUrl()
     {

--- a/src/Charcoal/Cms/EventCategory.php
+++ b/src/Charcoal/Cms/EventCategory.php
@@ -2,15 +2,16 @@
 
 namespace Charcoal\Cms;
 
-// Module `charcoal-base` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategoryInterface;
 use Charcoal\Object\CategoryTrait;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\Event;
 
 /**
- * Event category.
+ * Event Category
  */
 final class EventCategory extends Content implements CategoryInterface
 {
@@ -27,7 +28,7 @@ final class EventCategory extends Content implements CategoryInterface
     }
 
     /**
-     * @return Collection
+     * @return \Charcoal\Model\Collection|array
      */
     public function loadCategoryItems()
     {

--- a/src/Charcoal/Cms/EventInterface.php
+++ b/src/Charcoal/Cms/EventInterface.php
@@ -2,63 +2,68 @@
 
 namespace Charcoal\Cms;
 
+use DateTimeInterface;
+
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
 /**
  *
  */
 interface EventInterface
 {
     /**
-     * @param mixed $title News title (localized).
-     * @return \Charcoal\Translation\TranslationString
+     * @param  mixed $title Event title (localized).
+     * @return self
      */
     public function setTitle($title);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function title();
 
     /**
-     * @param mixed $subtitle News subtitle (localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $subtitle Event subtitle (localized).
+     * @return self
      */
     public function setSubtitle($subtitle);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function subtitle();
 
     /**
-     * @param mixed $content News content (localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $content Event content (localized).
+     * @return self
      */
     public function setContent($content);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function content();
 
     /**
-     * @param string|\DateTime $startDate Event starting date.
-     * @return EventInterface Chainable
+     * @param  string|DateTimeInterface $startDate Event starting date.
+     * @return self
      */
     public function setStartDate($startDate);
 
     /**
-     * @return \DateTime|null
+     * @return DateTimeInterface|null
      */
     public function startDate();
 
     /**
-     * @param string|\DateTime $endDate Event end date.
-     * @return EventInterface Chainable
+     * @param  string|DateTimeInterface $endDate Event end date.
+     * @return self
      */
     public function setEndDate($endDate);
 
     /**
-     * @return \DateTime|null
+     * @return DateTimeInterface|null
      */
     public function endDate();
 }

--- a/src/Charcoal/Cms/Faq.php
+++ b/src/Charcoal/Cms/Faq.php
@@ -2,7 +2,7 @@
 
 namespace Charcoal\Cms;
 
-// Intra-module (`charcoal-cms`) dependencies
+// From 'charcoal-cms'
 use Charcoal\Cms\AbstractFaq;
 use Charcoal\Cms\FaqCategory;
 

--- a/src/Charcoal/Cms/FaqCategory.php
+++ b/src/Charcoal/Cms/FaqCategory.php
@@ -2,11 +2,12 @@
 
 namespace Charcoal\Cms;
 
-// Module `charcoal-base` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategoryInterface;
 use Charcoal\Object\CategoryTrait;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\Faq;
 
 /**
@@ -27,7 +28,7 @@ final class FaqCategory extends Content implements CategoryInterface
     }
 
     /**
-     * @return Collection
+     * @return \Charcoal\Model\Collection|array
      */
     public function loadCategoryItems()
     {

--- a/src/Charcoal/Cms/FaqInterface.php
+++ b/src/Charcoal/Cms/FaqInterface.php
@@ -2,30 +2,33 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
 /**
  *
  */
 interface FaqInterface
 {
     /**
-     * @param mixed $question The question (localized).
-     * @return Faq Chainable
+     * @param  mixed $question The question (localized).
+     * @return self
      */
     public function setQuestion($question);
 
     /**
-     * @return \Charcoal\Translation\TranslationString|null
+     * @return Translation|string|null
      */
     public function question();
 
     /**
-     * @param mixed $answer The answer (localized).
-     * @return Faq Chainable
+     * @param  mixed $answer The answer (localized).
+     * @return self
      */
     public function setAnswer($answer);
 
     /**
-     * @return \Charcoal\Translation\TranslationString|null
+     * @return Translation|string|null
      */
     public function answer();
 }

--- a/src/Charcoal/Cms/Image.php
+++ b/src/Charcoal/Cms/Image.php
@@ -2,6 +2,7 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\AbstractImage;
 use Charcoal\Cms\ImageCategory;
 

--- a/src/Charcoal/Cms/ImageCategory.php
+++ b/src/Charcoal/Cms/ImageCategory.php
@@ -2,15 +2,16 @@
 
 namespace Charcoal\Cms;
 
-// Module `charcoal-base` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategoryInterface;
 use Charcoal\Object\CategoryTrait;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\Image;
 
 /**
- *
+ * Image Category
  */
 final class ImageCategory extends Content implements CategoryInterface
 {
@@ -27,7 +28,7 @@ final class ImageCategory extends Content implements CategoryInterface
     }
 
     /**
-     * @return Collection
+     * @return \Charcoal\Model\Collection|array
      */
     public function loadCategoryItems()
     {

--- a/src/Charcoal/Cms/ImageInterface.php
+++ b/src/Charcoal/Cms/ImageInterface.php
@@ -2,6 +2,9 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-cms'
+use Charcoal\Cms\DocumentInterface;
+
 /**
  *
  */

--- a/src/Charcoal/Cms/MetatagInterface.php
+++ b/src/Charcoal/Cms/MetatagInterface.php
@@ -2,6 +2,9 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
 /**
  *
  */
@@ -13,61 +16,61 @@ interface MetatagInterface
     public function canonicalUrl();
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaTitle();
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaDescription();
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function defaultMetaImage();
 
     /**
-     * @param mixed $title The meta title (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $title The meta title (localized).
+     * @return self
      */
     public function setMetaTitle($title);
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function metaTitle();
 
     /**
-     * @param mixed $description The meta description (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $description The meta description (localized).
+     * @return self
      */
     public function setMetaDescription($description);
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function metaDescription();
 
     /**
-     * @param mixed $image The meta image (localized).
-     * @return MetatageInterface Chainable
+     * @param  mixed $image The meta image (localized).
+     * @return self
      */
     public function setMetaImage($image);
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function metaImage();
 
     /**
-     * @param mixed $author The meta author (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $author The meta author (localized).
+     * @return self
      */
     public function setMetaAuthor($author);
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function metaAuthor();
 
@@ -77,8 +80,8 @@ interface MetatagInterface
     public function metaTags();
 
     /**
-     * @param string $appId The facebook App ID (numeric string).
-     * @return MetatagInterface Chainable
+     * @param  string $appId The facebook App ID (numeric string).
+     * @return self
      */
     public function setFacebookAppId($appId);
 
@@ -88,41 +91,41 @@ interface MetatagInterface
     public function facebookAppId();
 
     /**
-     * @param mixed $title The opengraph title (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $title The opengraph title (localized).
+     * @return self
      */
     public function setOpengraphTitle($title);
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphTitle();
 
     /**
-     * @param mixed $siteName The opengraph site name (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $siteName The opengraph site name (localized).
+     * @return self
      */
     public function setOpengraphSiteName($siteName);
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphSiteName();
 
     /**
-     * @param mixed $description The opengraph description (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $description The opengraph description (localized).
+     * @return self
      */
     public function setOpengraphDescription($description);
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphDescription();
 
     /**
-     * @param string $type The opengraph type.
-     * @return MetatagInterface Chainable
+     * @param  string $type The opengraph type.
+     * @return self
      */
     public function setOpengraphType($type);
 
@@ -132,35 +135,35 @@ interface MetatagInterface
     public function opengraphType();
 
     /**
-     * @param mixed $image The opengraph image (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $image The opengraph image (localized).
+     * @return self
      */
     public function setOpengraphImage($image);
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphImage();
 
     /**
-     * @param mixed $author The opengraph author (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $author The opengraph author (localized).
+     * @return self
      */
     public function setOpengraphAuthor($author);
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphAuthor();
 
     /**
-     * @param mixed $publisher The opengraph publisher (localized).
+     * @param  mixed $publisher The opengraph publisher (localized).
      * @return MetatagInterface
      */
     public function setOpengraphPulisher($publisher);
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphPublisher();
 

--- a/src/Charcoal/Cms/MetatagTrait.php
+++ b/src/Charcoal/Cms/MetatagTrait.php
@@ -2,27 +2,32 @@
 
 namespace Charcoal\Cms;
 
-use Charcoal\Translation\TranslationString;
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+use Charcoal\Translator\Translator;
 
 /**
-*
-*/
+ *
+ */
 trait MetatagTrait
 {
     /**
-     * @var TranslationString $metaTitle
+     * @var Translation|string|null
      */
     protected $metaTitle;
+
     /**
-     * @var TranslationString $metaDescription
+     * @var Translation|string|null
      */
     protected $metaDescription;
+
     /**
-     * @var TranslationString $metaImage
+     * @var Translation|string|null
      */
     protected $metaImage;
+
     /**
-     * @var TranslationString $metaAuthor
+     * @var Translation|string|null
      */
     protected $metaAuthor;
 
@@ -32,40 +37,39 @@ trait MetatagTrait
     protected $facebookAppId;
 
     /**
-     * @var TranslationString $opengraphTitle
+     * @var Translation|string|null
      */
     protected $opengraphTitle;
 
     /**
-     * @var TranslationString $siteName
+     * @var Translation|string|null
      */
     protected $opengraphSiteName;
 
     /**
-     * @var TranslationString $opengraphDescription
+     * @var Translation|string|null
      */
     protected $opengraphDescription;
 
     /**
-     * @var string $opengraphType
+     * @var string
      */
     protected $opengraphType;
 
     /**
-     * @var TranslationString $opengraphImage
+     * @var Translation|string|null
      */
     protected $opengraphImage;
 
     /**
-     * @var TranslationString $opengraphAuthor
+     * @var Translation|string|null
      */
     protected $opengraphAuthor;
 
     /**
-     * @var TranslationString $opengraphPublisher
+     * @var Translation|string|null
      */
     protected $opengraphPublisher;
-
 
     /**
      * @return string
@@ -73,32 +77,32 @@ trait MetatagTrait
     abstract public function canonicalUrl();
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     abstract public function defaultMetaTitle();
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     abstract public function defaultMetaDescription();
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     abstract public function defaultMetaImage();
 
     /**
-     * @param mixed $title The meta tile (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $title The meta tile (localized).
+     * @return self
      */
     public function setMetaTitle($title)
     {
-        $this->metaTitle = new TranslationString($title);
+        $this->metaTitle = $this->translator()->translation($title);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function metaTitle()
     {
@@ -106,17 +110,17 @@ trait MetatagTrait
     }
 
     /**
-     * @param mixed $description The meta description (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $description The meta description (localized).
+     * @return self
      */
     public function setMetaDescription($description)
     {
-        $this->metaDescription = new TranslationString($description);
+        $this->metaDescription = $this->translator()->translation($description);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function metaDescription()
     {
@@ -124,17 +128,17 @@ trait MetatagTrait
     }
 
     /**
-     * @param mixed $image The meta image (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $image The meta image (localized).
+     * @return self
      */
     public function setMetaImage($image)
     {
-        $this->metaImage = new TranslationString($image);
+        $this->metaImage = $this->translator()->translation($image);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function metaImage()
     {
@@ -142,17 +146,17 @@ trait MetatagTrait
     }
 
     /**
-     * @param mixed $author The meta author (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $author The meta author (localized).
+     * @return self
      */
     public function setMetaAuthor($author)
     {
-        $this->metaAuthor = new TranslationString($author);
+        $this->metaAuthor = $this->translator()->translation($author);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function metaAuthor()
     {
@@ -169,8 +173,8 @@ trait MetatagTrait
     }
 
     /**
-     * @param string $appId The facebook App ID (numeric string).
-     * @return MetatagInterface Chainable
+     * @param  string $appId The facebook App ID (numeric string).
+     * @return self
      */
     public function setFacebookAppId($appId)
     {
@@ -187,12 +191,12 @@ trait MetatagTrait
     }
 
     /**
-     * @param mixed $title The opengraph title (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $title The opengraph title (localized).
+     * @return self
      */
     public function setOpengraphTitle($title)
     {
-        $this->opengraphTitle = new TranslationString($title);
+        $this->opengraphTitle = $this->translator()->translation($title);
         return $this;
     }
 
@@ -201,7 +205,7 @@ trait MetatagTrait
      *
      * If not expilicitely defined, use the meta title as opengraph title.
      *
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphTitle()
     {
@@ -212,17 +216,17 @@ trait MetatagTrait
     }
 
     /**
-     * @param mixed $siteName The site name (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $siteName The site name (localized).
+     * @return self
      */
     public function setOpengraphSiteName($siteName)
     {
-        $this->opengraphSiteName = new TranslationString($siteName);
+        $this->opengraphSiteName = $this->translator()->translation($siteName);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphSiteName()
     {
@@ -230,17 +234,17 @@ trait MetatagTrait
     }
 
     /**
-     * @param mixed $description The opengraph description (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $description The opengraph description (localized).
+     * @return self
      */
     public function setOpengraphDescription($description)
     {
-        $this->opengraphDescription = new TranslationString($description);
+        $this->opengraphDescription = $this->translator()->translation($description);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphDescription()
     {
@@ -251,8 +255,8 @@ trait MetatagTrait
     }
 
     /**
-     * @param string $type The opengraph type.
-     * @return MetatagInterface Chainable
+     * @param  string $type The opengraph type.
+     * @return self
      */
     public function setOpengraphType($type)
     {
@@ -269,17 +273,17 @@ trait MetatagTrait
     }
 
     /**
-     * @param mixed $image The opengraph image (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $image The opengraph image (localized).
+     * @return self
      */
     public function setOpengraphImage($image)
     {
-        $this->opengraphImage = new TranslationString($image);
+        $this->opengraphImage = $this->translator()->translation($image);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphImage()
     {
@@ -290,17 +294,17 @@ trait MetatagTrait
     }
 
     /**
-     * @param mixed $author The opengraph author (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $author The opengraph author (localized).
+     * @return self
      */
     public function setOpengraphAuthor($author)
     {
-        $this->opengraphAuthor = new TranslationString($author);
+        $this->opengraphAuthor = $this->translator()->translation($author);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphAuthor()
     {
@@ -311,17 +315,17 @@ trait MetatagTrait
     }
 
     /**
-     * @param mixed $publisher The opengraph publisher (localized).
-     * @return MetatagInterface Chainable
+     * @param  mixed $publisher The opengraph publisher (localized).
+     * @return self
      */
     public function setOpengraphPulisher($publisher)
     {
-        $this->opengraphPublisher = new TranslationString($publisher);
+        $this->opengraphPublisher = $this->translator()->translation($publisher);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function opengraphPublisher()
     {
@@ -344,6 +348,7 @@ trait MetatagTrait
      * Prevents some problem where the defaultMetaTag method
      * content isn't set at the moment of setting the meta.
      * Should be called on preSave and preUpdate of the object.
+     *
      * @return self $this.
      */
     public function generateDefaultMetaTags()
@@ -366,8 +371,9 @@ trait MetatagTrait
      * what's in the meta.
      * Possible param type:
      * - [ lang => value, lang => value ]
-     * - TranslationString
+     * - Translation
      * - null
+     *
      * @param  mixed $meta Current meta value.
      * @return boolean       Empty or not.
      */
@@ -380,14 +386,14 @@ trait MetatagTrait
         // From back-end form which post meta_description[lang]=value
         // Gives [ lang => value ] as value
         if (is_array($meta)) {
-            $meta = new TranslationString($meta);
+            $meta = $this->translator()->translation($meta);
         }
 
         // If one value is set in whatever language,
         // this is NOT empty.
-        if ($meta instanceof TranslationString) {
+        if ($meta instanceof Translation) {
             $empty = true;
-            foreach ($meta->all() as $lang => $val) {
+            foreach ($meta->data() as $lang => $val) {
                 if ($val && $val != '') {
                     $empty = false;
                 }
@@ -396,4 +402,9 @@ trait MetatagTrait
         }
         return true;
     }
+
+    /**
+     * @return Translator
+     */
+    abstract protected function translator();
 }

--- a/src/Charcoal/Cms/News.php
+++ b/src/Charcoal/Cms/News.php
@@ -2,13 +2,13 @@
 
 namespace Charcoal\Cms;
 
-// Intra-module (`charcoal-cms`) dependencies
+// From 'charcoal-cms'
 use Charcoal\Cms\AbstractNew;
 use Charcoal\Cms\NewsCategory;
 
 /**
-* CMS News
-*/
+ * CMS News
+ */
 final class News extends AbstractNews
 {
     /**

--- a/src/Charcoal/Cms/NewsCategory.php
+++ b/src/Charcoal/Cms/NewsCategory.php
@@ -2,15 +2,16 @@
 
 namespace Charcoal\Cms;
 
-// Module `charcoal-base` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategoryInterface;
 use Charcoal\Object\CategoryTrait;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\News;
 
 /**
- * News category
+ * News Category
  */
 final class NewsCategory extends Content implements CategoryInterface
 {
@@ -27,7 +28,7 @@ final class NewsCategory extends Content implements CategoryInterface
     }
 
     /**
-     * @return Collection
+     * @return \Charcoal\Model\Collection|array
      */
     public function loadCategoryItems()
     {

--- a/src/Charcoal/Cms/NewsInterface.php
+++ b/src/Charcoal/Cms/NewsInterface.php
@@ -8,57 +8,57 @@ namespace Charcoal\Cms;
 interface NewsInterface
 {
     /**
-     * @param mixed $title News title (localized).
-     * @return \Charcoal\Translation\TranslationString
+     * @param  mixed $title News title (localized).
+     * @return self
      */
     public function setTitle($title);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function title();
 
     /**
-     * @param mixed $subtitle News subtitle (localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $subtitle News subtitle (localized).
+     * @return self
      */
     public function setSubtitle($subtitle);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function subtitle();
 
     /**
-     * @param mixed $content News content (localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $content News content (localized).
+     * @return self
      */
     public function setContent($content);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function content();
 
     /**
-     * @param mixed $newsDate The news date.
-     * @return ObjectRevision Chainable
+     * @param  mixed $newsDate The news date.
+     * @return self
      */
     public function setNewsDate($newsDate);
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function newsDate();
 
     /**
-     * @param mixed $url The URL that provides additional information ont he news (localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $url The URL that provides additional information ont he news (localized).
+     * @return self
      */
     public function setInfoUrl($url);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function infoUrl();
 }

--- a/src/Charcoal/Cms/Route/EventRoute.php
+++ b/src/Charcoal/Cms/Route/EventRoute.php
@@ -2,23 +2,30 @@
 
 namespace Charcoal\Cms\Route;
 
+// From Pimple
 use Pimple\Container;
 
-// From PSR-7 (HTTP Messaging)
+// From PSR-7
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+
+// From 'charcoal-translator'
+use Charcoal\Translator\TranslatorAwareTrait;
 
 // From 'charcoal-app'
 use Charcoal\App\Route\TemplateRoute;
 
-// From `charcoal-translation`
-use Charcoal\Translation\TranslationConfig;
+// From 'charcoal-cms'
+use Charcoal\Cms\EventInterface;
+use Charcoal\Object\RoutableInterface;
 
 /**
  * Event Route Handler
  */
 class EventRoute extends TemplateRoute
 {
+    use TranslatorAwareTrait;
+
     /**
      * URI path.
      *
@@ -29,7 +36,7 @@ class EventRoute extends TemplateRoute
     /**
      * The event object matching the URI path.
      *
-     * @var \Charcoal\Cms\EventInterface|\Charcoal\Object\RoutableInterface
+     * @var EventInterface|RoutableInterface
      */
     private $event;
 
@@ -41,9 +48,9 @@ class EventRoute extends TemplateRoute
     private $objType = 'charcoal/cms/event';
 
     /**
-     * @param array|\ArrayAccess $data Class depdendencies.
+     * @param array $data Class depdendencies.
      */
-    public function __construct($data)
+    public function __construct(array $data)
     {
         parent::__construct($data);
         $this->path = ltrim($data['path'], '/');
@@ -67,8 +74,11 @@ class EventRoute extends TemplateRoute
      * @param  ResponseInterface $response  A PSR-7 compatible Response instance.
      * @return ResponseInterface
      */
-    public function __invoke(Container $container, RequestInterface $request, ResponseInterface $response)
-    {
+    public function __invoke(
+        Container $container,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
         $config = $this->config();
 
         $event = $this->loadEventFromPath($container);
@@ -97,8 +107,9 @@ class EventRoute extends TemplateRoute
     }
 
     /**
-     * @param Container $container Pimple DI container.
-     * @return \Charcoal\Cms\EventInterface
+     * @todo   Add support for `@see setlocale()`; {@see GenericRoute::setLocale()}
+     * @param  Container $container Pimple DI container.
+     * @return EventInterface
      */
     protected function loadEventFromPath(Container $container)
     {
@@ -107,12 +118,11 @@ class EventRoute extends TemplateRoute
             $objType = (isset($config['obj_type']) ? $config['obj_type'] : $this->objType);
 
             $this->event = $container['model/factory']->create($objType);
+            $this->setTranslator($container['translator']);
 
-            $translator = TranslationConfig::instance();
-
-            $langs = $translator->availableLanguages();
+            $langs = $container['translator']->availableLocales();
             $lang  = $this->event->loadFromL10n('slug', $this->path, $langs);
-            $translator->setCurrentLanguage($lang);
+            $container['translator']->setLocale($lang);
         }
 
         return $this->event;

--- a/src/Charcoal/Cms/Route/SectionRoute.php
+++ b/src/Charcoal/Cms/Route/SectionRoute.php
@@ -2,23 +2,30 @@
 
 namespace Charcoal\Cms\Route;
 
+// From Pimple
 use Pimple\Container;
 
-// From PSR-7 (HTTP Messaging)
+// From PSR-7
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+
+// From 'charcoal-translator'
+use Charcoal\Translator\TranslatorAwareTrait;
 
 // From 'charcoal-app'
 use Charcoal\App\Route\TemplateRoute;
 
-// From 'charcoal-translation'
-use Charcoal\Translation\TranslationConfig;
+// From 'charcoal-cms'
+use Charcoal\Cms\SectionInterface;
+use Charcoal\Object\RoutableInterface;
 
 /**
  * Section Route Handler
  */
 class SectionRoute extends TemplateRoute
 {
+    use TranslatorAwareTrait;
+
     /**
      * URI path.
      *
@@ -29,7 +36,7 @@ class SectionRoute extends TemplateRoute
     /**
      * The section object matching the URI path.
      *
-     * @var \Charcoal\Cms\SectionInterface|\Charcoal\Object\RoutableInterface
+     * @var SectionInterface|RoutableInterface
      */
     private $section;
 
@@ -41,9 +48,9 @@ class SectionRoute extends TemplateRoute
     private $objType = 'charcoal/cms/section';
 
     /**
-     * @param array|\ArrayAccess $data Class depdendencies.
+     * @param array $data Class depdendencies.
      */
-    public function __construct($data)
+    public function __construct(array $data)
     {
         parent::__construct($data);
 
@@ -68,8 +75,11 @@ class SectionRoute extends TemplateRoute
      * @param  ResponseInterface $response  A PSR-7 compatible Response instance.
      * @return ResponseInterface
      */
-    public function __invoke(Container $container, RequestInterface $request, ResponseInterface $response)
-    {
+    public function __invoke(
+        Container $container,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
         $config = $this->config();
 
         $section = $this->loadSectionFromPath($container);
@@ -99,8 +109,9 @@ class SectionRoute extends TemplateRoute
     }
 
     /**
-     * @param Container $container Pimple DI container.
-     * @return \Charcoal\Cms\SectionInterface
+     * @todo   Add support for `@see setlocale()`; {@see GenericRoute::setLocale()}
+     * @param  Container $container Pimple DI container.
+     * @return SectionInterface
      */
     protected function loadSectionFromPath(Container $container)
     {
@@ -110,11 +121,9 @@ class SectionRoute extends TemplateRoute
 
             $this->section = $container['model/factory']->create($objType);
 
-            $translator = TranslationConfig::instance();
-
-            $langs = $translator->availableLanguages();
+            $langs = $container['translator']->availableLocales();
             $lang  = $this->section->loadFromL10n('slug', $this->path, $langs);
-            $translator->setCurrentLanguage($lang);
+            $container['translator']->setLocale($lang);
         }
 
         return $this->section;

--- a/src/Charcoal/Cms/SearchableInterface.php
+++ b/src/Charcoal/Cms/SearchableInterface.php
@@ -2,14 +2,17 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
 /**
  *
  */
 interface SearchableInterface
 {
     /**
-     * @param array $properties The properties to search into.
-     * @return SearchableInterface Chainable
+     * @param  array $properties The properties to search into.
+     * @return self
      */
     public function setSearchProperties(array $properties);
 
@@ -19,13 +22,13 @@ interface SearchableInterface
     public function searchProperties();
 
     /**
-     * @param mixed $keywords The search keywords (localized).
-     * @return SearchableInterface Chainable
+     * @param  mixed $keywords The search keywords (localized).
+     * @return self
      */
     public function setSearchKeywords($keywords);
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function searchKeywords();
 }

--- a/src/Charcoal/Cms/SearchableTrait.php
+++ b/src/Charcoal/Cms/SearchableTrait.php
@@ -2,7 +2,8 @@
 
 namespace Charcoal\Cms;
 
-use Charcoal\Translation\TranslationString;
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
 
 /**
  * Default implementation, as Trait, of the SearchableInterface
@@ -10,18 +11,18 @@ use Charcoal\Translation\TranslationString;
 trait SearchableTrait
 {
     /**
-     * @var array $searchProperties
+     * @var array
      */
     private $searchProperties = [];
 
     /**
-     * @var TranslationString $searchKeywords
+     * @var Translation|string|null
      */
     private $searchKeywords;
 
     /**
-     * @param array $properties The properties to search into.
-     * @return SearchableInterface Chainable
+     * @param  array $properties The properties to search into.
+     * @return self
      */
     public function setSearchProperties(array $properties)
     {
@@ -38,17 +39,17 @@ trait SearchableTrait
     }
 
     /**
-     * @param mixed $keywords The search keywords (localized).
-     * @return SearchableInterface Chainable
+     * @param  mixed $keywords The search keywords (localized).
+     * @return self
      */
     public function setSearchKeywords($keywords)
     {
-        $this->searchKeywords = new TranslationString($keywords);
+        $this->searchKeywords = $this->translator()->translation($keywords);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function searchKeywords()
     {

--- a/src/Charcoal/Cms/Section.php
+++ b/src/Charcoal/Cms/Section.php
@@ -2,6 +2,9 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-cms'
+use Charcoal\Cms\AbstractSection;
+
 /**
  * CMS Section
  */

--- a/src/Charcoal/Cms/Section/BlocksSection.php
+++ b/src/Charcoal/Cms/Section/BlocksSection.php
@@ -2,7 +2,7 @@
 
 namespace Charcoal\Cms\Section;
 
-// Parent namespace dependencies
+// From 'charcoal-cms'
 use Charcoal\Cms\AbstractSection;
 
 /**

--- a/src/Charcoal/Cms/Section/ContentSection.php
+++ b/src/Charcoal/Cms/Section/ContentSection.php
@@ -2,6 +2,7 @@
 
 namespace Charcoal\Cms\Section;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\AbstractSection;
 
 /**

--- a/src/Charcoal/Cms/Section/EmptySection.php
+++ b/src/Charcoal/Cms/Section/EmptySection.php
@@ -2,6 +2,7 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\AbstractSection;
 
 /**

--- a/src/Charcoal/Cms/Section/ExternalSection.php
+++ b/src/Charcoal/Cms/Section/ExternalSection.php
@@ -2,8 +2,10 @@
 
 namespace Charcoal\Cms;
 
-use Charcoal\Translation\TranslationString;
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\AbstractSection;
 
 /**
@@ -14,22 +16,22 @@ use Charcoal\Cms\AbstractSection;
 class ExternalSection extends AbstractSection
 {
     /**
-     * @var TranslationString $externalUrl
+     * @var Translation|string|null
      */
     private $externalUrl;
 
     /**
-     * @param mixed $url The external URL (localized).
-     * @return ExternalSection Chainable
+     * @param  mixed $url The external URL (localized).
+     * @return self
      */
     public function setExternalUrl($url)
     {
-        $this->externalUrl = new TranslationString($url);
+        $this->externalUrl = $this->translator()->translation($url);
         return $this;
     }
 
     /**
-     * @return TranslationString
+     * @return Translation|string|null
      */
     public function externalUrl()
     {

--- a/src/Charcoal/Cms/SectionInterface.php
+++ b/src/Charcoal/Cms/SectionInterface.php
@@ -2,14 +2,17 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
 /**
  *
  */
 interface SectionInterface
 {
     /**
-     * @param string $type The section type.
-     * @return SectionInterface Chainable
+     * @param  string $type The section type.
+     * @return self
      */
     public function setSectionType($type);
 
@@ -19,24 +22,24 @@ interface SectionInterface
     public function sectionType();
 
     /**
-     * @param mixed $title Section title (localized).
-     * @return SectionInterface Chainable
+     * @param  mixed $title Section title (localized).
+     * @return self
      */
     public function setTitle($title);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function title();
 
     /**
-     * @param mixed $subtitle Section subtitle (localized).
-     * @return SectionInterface Chainable
+     * @param  mixed $subtitle Section subtitle (localized).
+     * @return self
      */
     public function setSubtitle($subtitle);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function subtitle();
 }

--- a/src/Charcoal/Cms/Tag.php
+++ b/src/Charcoal/Cms/Tag.php
@@ -4,10 +4,13 @@ namespace Charcoal\Cms;
 
 use Exception;
 
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
+// From 'charcoal-cms'
 use Charcoal\Object\CategoryInterface;
 use Charcoal\Object\CategoryTrait;
 use Charcoal\Object\Content;
-use Charcoal\Translation\TranslationString;
 
 /**
  * CMS Tag
@@ -18,20 +21,23 @@ class Tag extends Content implements
     use CategoryTrait;
 
     /**
-     * @var object|string $name The tag's name.
+     * The tag's name.
+     *
+     * @var Translation|string|null
      */
     protected $name;
 
     /**
-     * @var string $color The tag's color.
+     * The tag's color.
+     *
+     * @var string
      */
     protected $color;
 
     /**
-     * Section constructor.
-     * @param array|null $data The object's data options.
+     * @param array $data The object's data options.
      */
-    public function __construct($data = null)
+    public function __construct(array $data = null)
     {
         parent::__construct($data);
 
@@ -56,7 +62,9 @@ class Tag extends Content implements
     // ==========================================================================
 
     /**
-     * @return mixed The tag's name.
+     * The tag's name.
+     *
+     * @return Translation|string|null
      */
     public function name()
     {
@@ -64,7 +72,9 @@ class Tag extends Content implements
     }
 
     /**
-     * @return mixed The tag's color.
+     * The tag's color.
+     *
+     * @return mixed
      */
     public function color()
     {
@@ -76,23 +86,18 @@ class Tag extends Content implements
     // ==========================================================================
 
     /**
-     * @param string|string[] $name The name of the tag.
-     * @return self chainable
+     * @param  mixed $name The name of the tag.
+     * @return self
      */
     public function setName($name)
     {
-        if (TranslationString::isTranslatable($name)) {
-            $this->name = new TranslationString($name);
-        } else {
-            $this->name = null;
-        }
-
+        $this->name = $this->translator()->translation($name);
         return $this;
     }
 
     /**
-     * @param string $color The color in HEX format as a string.
-     * @return self chainable
+     * @param  string $color The color in HEX format as a string.
+     * @return self
      */
     public function setColor($color)
     {

--- a/src/Charcoal/Cms/TemplateableInterface.php
+++ b/src/Charcoal/Cms/TemplateableInterface.php
@@ -10,8 +10,8 @@ interface TemplateableInterface
     /**
      * Set the renderable object's template identifier.
      *
-     * @param mixed $template The template ID.
-     * @return TemplateableInterface Chainable
+     * @param  mixed $template The template ID.
+     * @return self
      */
     public function setTemplateIdent($template);
 
@@ -26,7 +26,7 @@ interface TemplateableInterface
      * Set the renderable object's template controller identifier.
      *
      * @param  mixed $ident The template controller identifier.
-     * @return TemplateableInterface Chainable
+     * @return self
      */
     public function setControllerIdent($ident);
 
@@ -40,8 +40,8 @@ interface TemplateableInterface
     /**
      * Customize the template's options.
      *
-     * @param array|string $options Template options.
-     * @return TemplateableInterface Chainable
+     * @param  array|string $options Template options.
+     * @return self
      */
     public function setTemplateOptions($options);
 

--- a/src/Charcoal/Cms/TemplateableTrait.php
+++ b/src/Charcoal/Cms/TemplateableTrait.php
@@ -33,7 +33,7 @@ trait TemplateableTrait
      * Set the renderable object's template identifier.
      *
      * @param  mixed $template The template ID.
-     * @return TemplateableInterface Chainable
+     * @return self
      */
     public function setTemplateIdent($template)
     {
@@ -56,7 +56,7 @@ trait TemplateableTrait
      * Set the renderable object's template controller identifier.
      *
      * @param  mixed $ident The template controller identifier.
-     * @return TemplateableInterface Chainable
+     * @return self
      */
     public function setControllerIdent($ident)
     {
@@ -79,7 +79,7 @@ trait TemplateableTrait
      * Customize the template's options.
      *
      * @param  mixed $options Template options.
-     * @return TemplateableInterface Chainable
+     * @return self
      */
     public function setTemplateOptions($options)
     {

--- a/src/Charcoal/Cms/Text.php
+++ b/src/Charcoal/Cms/Text.php
@@ -2,6 +2,7 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\AbstractText;
 use Charcoal\Cms\TextCategory;
 

--- a/src/Charcoal/Cms/TextCategory.php
+++ b/src/Charcoal/Cms/TextCategory.php
@@ -2,15 +2,16 @@
 
 namespace Charcoal\Cms;
 
-// Module `charcoal-base` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategoryInterface;
 use Charcoal\Object\CategoryTrait;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\Text;
 
 /**
- * Text category
+ * Text Category
  */
 final class TextCategory extends Content implements CategoryInterface
 {
@@ -27,7 +28,7 @@ final class TextCategory extends Content implements CategoryInterface
     }
 
     /**
-     * @return Collection
+     * @return \Charcoal\Model\Collection|array
      */
     public function loadCategoryItems()
     {

--- a/src/Charcoal/Cms/TextInterface.php
+++ b/src/Charcoal/Cms/TextInterface.php
@@ -2,41 +2,44 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
+
 /**
  *
  */
 interface TextInterface
 {
     /**
-     * @param mixed $title News title (localized).
-     * @return \Charcoal\Translation\TranslationString
+     * @param  mixed $title Text title (localized).
+     * @return self
      */
     public function setTitle($title);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function title();
 
     /**
-     * @param mixed $subtitle News subtitle (localized).
-     * @return NewsInterface Chainable
+     * @param mixed $subtitle Text subtitle (localized).
+     * @return self
      */
     public function setSubtitle($subtitle);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function subtitle();
 
     /**
-     * @param mixed $content News content (localized).
-     * @return NewsInterface Chainable
+     * @param  mixed $content Text content (localized).
+     * @return self
      */
     public function setContent($content);
 
     /**
-     * @return \Charcoal\Translation\TranslationString
+     * @return Translation|string|null
      */
     public function content();
 }

--- a/src/Charcoal/Cms/Video.php
+++ b/src/Charcoal/Cms/Video.php
@@ -2,7 +2,8 @@
 
 namespace Charcoal\Cms;
 
-use \Charcoal\Cms\AbstractVideo;
+// From 'charcoal-cms'
+use Charcoal\Cms\AbstractVideo;
 use Charcoal\Cms\VideoCategory;
 
 /**

--- a/src/Charcoal/Cms/VideoCategory.php
+++ b/src/Charcoal/Cms/VideoCategory.php
@@ -2,15 +2,16 @@
 
 namespace Charcoal\Cms;
 
-// Module `charcoal-base` dependencies
+// From 'charcoal-object'
 use Charcoal\Object\Content;
 use Charcoal\Object\CategoryInterface;
 use Charcoal\Object\CategoryTrait;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\Video;
 
 /**
- * Video category
+ * Video Category
  */
 final class VideoCategory extends Content implements CategoryInterface
 {
@@ -27,7 +28,7 @@ final class VideoCategory extends Content implements CategoryInterface
     }
 
     /**
-     * @return Collection
+     * @return \Charcoal\Model\Collection|array
      */
     public function loadCategoryItems()
     {

--- a/src/Charcoal/Cms/VideoInterface.php
+++ b/src/Charcoal/Cms/VideoInterface.php
@@ -2,6 +2,9 @@
 
 namespace Charcoal\Cms;
 
+// From 'charcoal-cms'
+use Charcoal\Cms\DocumentInterface;
+
 /**
  *
  */

--- a/src/Charcoal/Property/TemplateProperty.php
+++ b/src/Charcoal/Property/TemplateProperty.php
@@ -2,13 +2,17 @@
 
 namespace Charcoal\Property;
 
-use \RuntimeException;
-use \InvalidArgumentException;
+use PDO;
 
-use \Pimple\Container;
+use RuntimeException;
+use InvalidArgumentException;
 
-use \Charcoal\Property\SelectablePropertyInterface;
-use \Charcoal\Property\SelectablePropertyTrait;
+// From Pimple
+use Pimple\Container;
+
+// From 'charcoal-cms'
+use Charcoal\Property\SelectablePropertyInterface;
+use Charcoal\Property\SelectablePropertyTrait;
 
 /**
  * Object Property holds a reference to an external object.
@@ -88,6 +92,6 @@ class TemplateProperty extends AbstractProperty implements SelectablePropertyInt
      */
     public function sqlPdoType()
     {
-        return \PDO::PARAM_STR;
+        return PDO::PARAM_STR;
     }
 }

--- a/tests/Charcoal/Cms/ContainerIntegrationTrait.php
+++ b/tests/Charcoal/Cms/ContainerIntegrationTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Charcoal\Tests\Cms;
+
+// From Pimple
+use Pimple\Container;
+
+// From 'charcoal-cms/tests'
+use Charcoal\Tests\Cms\ContainerProvider;
+
+/**
+ * Integrates Charcoal's service container into PHPUnit.
+ *
+ * Ensures Charcoal framework is set-up for each test.
+ */
+trait ContainerIntegrationTrait
+{
+    /**
+     * @var Container
+     */
+    private $container;
+
+    /**
+     * @see    ContainerProvider
+     * @return Container
+     */
+    private function getContainer()
+    {
+        if ($this->container === null) {
+            $provider  = new ContainerProvider();
+            $container = new Container();
+
+            $provider->registerModelDependencies($container);
+
+            $this->container = $container;
+        }
+
+        return $this->container;
+    }
+}

--- a/tests/Charcoal/Cms/DocumentCategoryTest.php
+++ b/tests/Charcoal/Cms/DocumentCategoryTest.php
@@ -2,33 +2,34 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
-
-use Psr\Log\NullLogger;
-use Cache\Adapter\Void\VoidCachePool;
-
-use Charcoal\Model\Service\MetadataLoader;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\DocumentCategory;
 use Charcoal\Cms\Document;
 
-class DocumentCategoryTest extends PHPUnit_Framework_TestCase
+/**
+ *
+ */
+class DocumentCategoryTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var DocumentCategory
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new DocumentCategory([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container' => $container,
+            'logger'    => $container['logger']
         ]);
     }
 

--- a/tests/Charcoal/Cms/DocumentTest.php
+++ b/tests/Charcoal/Cms/DocumentTest.php
@@ -2,46 +2,45 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
-
-use Psr\Log\NullLogger;
-use Cache\Adapter\Void\VoidCachePool;
-
-use Charcoal\Model\Service\MetadataLoader;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\Document;
 use Charcoal\Cms\DocumentCategory;
 
 /**
  *
  */
-class DocumentTest extends PHPUnit_Framework_TestCase
+class DocumentTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var Document
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new Document([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container'       => $container,
+            'logger'          => $container['logger'],
+            'metadata_loader' => $container['metadata/loader']
         ]);
     }
 
     public function testSetData()
     {
         $ret = $this->obj->setData([
-            'name'=>'foo',
-            'file'=>'foobar',
-            'base_path'=>'baz',
-            'base_url'=>'http://example.com/c'
+            'name'      => 'foo',
+            'file'      => 'foobar',
+            'base_path' => 'baz',
+            'base_url'  => 'http://example.com/c'
         ]);
         $this->assertSame($ret, $this->obj);
 

--- a/tests/Charcoal/Cms/EventCategoryTest.php
+++ b/tests/Charcoal/Cms/EventCategoryTest.php
@@ -2,31 +2,34 @@
 
 namespace Charcoal\Cms\Tests;
 
-use Psr\Log\NullLogger;
-use Cache\Adapter\Void\VoidCachePool;
-
-use Charcoal\Model\Service\MetadataLoader;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\EventCategory;
 use Charcoal\Cms\Event;
 
+/**
+ *
+ */
 class EventCategoryTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var EventCategory
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new EventCategory([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container' => $container,
+            'logger'    => $container['logger']
         ]);
     }
 

--- a/tests/Charcoal/Cms/EventTest.php
+++ b/tests/Charcoal/Cms/EventTest.php
@@ -2,34 +2,40 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
+use DateTime;
 
-use Pimple\Container;
+// From 'charcoal-object'
+use Charcoal\Object\ObjectRoute;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\Event;
 use Charcoal\Cms\EventCategory;
-
-use Charcoal\Tests\Cms\ContainerProvider;
 
 /**
  *
  */
-class EventTest extends PHPUnit_Framework_TestCase
+class EventTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var Event
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $provider = new ContainerProvider();
+        $container = $this->getContainer();
 
-        $container = new Container();
-        $provider->registerBaseServices($container);
-        $provider->registerMetadataLoader($container);
-        $provider->registerModelFactory($container);
-        $provider->registerSourceFactory($container);
-        $provider->registerPropertyFactory($container);
-        $provider->registerModelCollectionLoader($container);
+        $route = $container['model/factory']->get(ObjectRoute::class);
+        if ($route->source()->tableExists() === false) {
+            $route->source()->createTable();
+        }
 
         $this->obj = new Event([
             'container'         => $container,
@@ -43,19 +49,18 @@ class EventTest extends PHPUnit_Framework_TestCase
     public function testSetData()
     {
         $ret = $this->obj->setData([
-            'title'=>'Example title',
-            'subtitle'=>'Subtitle',
-            'content'=>'foobar',
-            'start_date'=>'2015-01-01 20:00:00',
-            'end_date'=>'2015-01-01 21:30:00'
+            'title'      => 'Example title',
+            'subtitle'   => 'Subtitle',
+            'content'    => 'foobar',
+            'start_date' => '2015-01-01 20:00:00',
+            'end_date'   => '2015-01-01 21:30:00'
         ]);
 
         $this->assertSame($ret, $this->obj);
         $this->assertEquals('Example title', (string)$this->obj->title());
         $this->assertEquals('Subtitle', (string)$this->obj->subtitle());
         $this->assertEquals('foobar', (string)$this->obj->content());
-        $this->assertEquals(new \DateTime('2015-01-01 20:00:00
-            '), $this->obj->startDate());
+        $this->assertEquals(new DateTime('2015-01-01 20:00:00'), $this->obj->startDate());
     }
 
     public function testSetTitle()
@@ -119,7 +124,7 @@ class EventTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(null, $this->obj->startDate());
         $ret = $this->obj->setStartDate('2016-02-02');
         $this->assertSame($ret, $this->obj);
-        $this->assertEquals(new \DateTime('2016-02-02'), $ret->startDate());
+        $this->assertEquals(new DateTime('2016-02-02'), $ret->startDate());
 
         $this->obj->setStartDate(null);
         $this->assertEquals(null, $this->obj->startDate());
@@ -139,7 +144,7 @@ class EventTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(null, $this->obj->endDate());
         $ret = $this->obj->setEndDate('2016-02-02');
         $this->assertSame($ret, $this->obj);
-        $this->assertEquals(new \DateTime('2016-02-02'), $ret->endDate());
+        $this->assertEquals(new DateTime('2016-02-02'), $ret->endDate());
 
         $this->obj->setEndDate(null);
         $this->assertEquals(null, $this->obj->endDate());
@@ -183,23 +188,25 @@ class EventTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Barfoo', (string)$this->obj->metaDescription());
     }
 
-    // public function testMetaImageDefaultsToImage()
-    // {
-    //     $this->assertEquals('', (string)$this->obj->metaImage());
+    /*
+    public function testMetaImageDefaultsToImage()
+    {
+        $this->assertEquals('', (string)$this->obj->metaImage());
 
-    //     $this->obj->setImage('Foo.png');
-    //     $this->assertSame($this->obj->image(), $this->obj->metaImage());
-    //     $this->assertEquals('Foo.png', (string)$this->obj->metaImage());
+        $this->obj->setImage('Foo.png');
+        $this->assertSame($this->obj->image(), $this->obj->metaImage());
+        $this->assertEquals('Foo.png', (string)$this->obj->metaImage());
 
-    //     $this->obj->setMetaImage('Bar.jpg');
-    //     $this->assertEquals('Bar.jpg', (string)$this->obj->metaImage());
-    // }
+        $this->obj->setMetaImage('Bar.jpg');
+        $this->assertEquals('Bar.jpg', (string)$this->obj->metaImage());
+    }
+    */
 
     public function testSaveGeneratesSlug()
     {
         $this->assertEquals('', $this->obj->slug());
         $this->obj->setData([
-            'title'=>'foo'
+            'title' => 'foo'
         ]);
         $this->obj->save();
 
@@ -210,7 +217,7 @@ class EventTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals('', $this->obj->slug());
         $this->obj->setData([
-            'title'=>'foo'
+            'title' => 'foo'
         ]);
         $this->obj->update();
 
@@ -224,9 +231,9 @@ class EventTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', (string)$this->obj->metaImage());
 
         $this->obj->setData([
-            'title'=>'foo',
-            'content'=>'<p>Foo bar</p>',
-            'image' => 'x.jpg'
+            'title'   => 'foo',
+            'content' => '<p>Foo bar</p>',
+            'image'   => 'x.jpg'
         ]);
         $this->obj->save();
 
@@ -242,9 +249,9 @@ class EventTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', (string)$this->obj->metaImage());
 
         $this->obj->setData([
-            'title'=>'foo',
-            'content'=>'<p>Foo bar</p>',
-            'image' => 'x.jpg'
+            'title'   => 'foo',
+            'content' => '<p>Foo bar</p>',
+            'image'   => 'x.jpg'
         ]);
         $this->obj->update();
 

--- a/tests/Charcoal/Cms/FaqCategoryTest.php
+++ b/tests/Charcoal/Cms/FaqCategoryTest.php
@@ -2,13 +2,7 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
-
-use Psr\Log\NullLogger;
-use Cache\Adapter\Void\VoidCachePool;
-
-use Charcoal\Model\Service\MetadataLoader;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\FaqCategory;
 use Charcoal\Cms\Faq;
 
@@ -17,21 +11,25 @@ use Charcoal\Cms\Faq;
  */
 class FaqCategoryTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var FaqCategory
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new FaqCategory([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container' => $container,
+            'logger'    => $container['logger']
         ]);
     }
 

--- a/tests/Charcoal/Cms/FaqTest.php
+++ b/tests/Charcoal/Cms/FaqTest.php
@@ -2,44 +2,42 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
-
-use Psr\Log\NullLogger;
-use Cache\Adapter\Void\VoidCachePool;
-
-use Charcoal\Model\Service\MetadataLoader;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\Faq;
 use Charcoal\Cms\FaqCategory;
 
 /**
  *
  */
-class FaqTest extends PHPUnit_Framework_TestCase
+class FaqTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var Faq
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new Faq([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container' => $container,
+            'logger'    => $container['logger']
         ]);
     }
 
     public function testSetData()
     {
         $ret = $this->obj->setData([
-            'question'=>'Foo?',
-            'answer'=>'Bar'
+            'question' => 'Foo?',
+            'answer'   => 'Bar'
         ]);
         $this->assertSame($ret, $this->obj);
         $this->assertEquals('Foo?', (string)$this->obj->question());

--- a/tests/Charcoal/Cms/ImageCategoryTest.php
+++ b/tests/Charcoal/Cms/ImageCategoryTest.php
@@ -2,36 +2,34 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
-
-use Psr\Log\NullLogger;
-use Cache\Adapter\Void\VoidCachePool;
-
-use Charcoal\Model\Service\MetadataLoader;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\ImageCategory;
 use Charcoal\Cms\Image;
 
 /**
  *
  */
-class ImageCategoryTest extends PHPUnit_Framework_TestCase
+class ImageCategoryTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var ImageCategory
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new ImageCategory([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container' => $container,
+            'logger'    => $container['logger']
         ]);
     }
 

--- a/tests/Charcoal/Cms/ImageTest.php
+++ b/tests/Charcoal/Cms/ImageTest.php
@@ -2,36 +2,34 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
-
-use Psr\Log\NullLogger;
-use Cache\Adapter\Void\VoidCachePool;
-
-use Charcoal\Model\Service\MetadataLoader;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\Image;
 use Charcoal\Cms\ImageCategory;
 
 /**
  *
  */
-class ImageTest extends PHPUnit_Framework_TestCase
+class ImageTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var Image
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new Image([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container' => $container,
+            'logger'    => $container['logger']
         ]);
     }
 

--- a/tests/Charcoal/Cms/NewsCategoryTest.php
+++ b/tests/Charcoal/Cms/NewsCategoryTest.php
@@ -2,13 +2,7 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
-
-use Psr\Log\NullLogger;
-use Cache\Adapter\Void\VoidCachePool;
-
-use Charcoal\Model\Service\MetadataLoader;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\NewsCategory;
 use Charcoal\Cms\News;
 
@@ -17,21 +11,25 @@ use Charcoal\Cms\News;
  */
 class NewsCategoryTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var NewsCategory
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new NewsCategory([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container' => $container,
+            'logger'    => $container['logger']
         ]);
     }
 

--- a/tests/Charcoal/Cms/NewsTest.php
+++ b/tests/Charcoal/Cms/NewsTest.php
@@ -2,36 +2,40 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
-
 use DateTime;
 
-use Pimple\Container;
+// From 'charcoal-object'
+use Charcoal\Object\ObjectRoute;
 
+// From 'charcoal-cms'
 use Charcoal\Cms\News;
 use Charcoal\Cms\NewsCategory;
-
-use Charcoal\Tests\Cms\ContainerProvider;
 
 /**
  *
  */
-class NewsTest extends PHPUnit_Framework_TestCase
+class NewsTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var News
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $provider = new ContainerProvider();
+        $container = $this->getContainer();
 
-        $container = new Container();
-        $provider->registerBaseServices($container);
-        $provider->registerMetadataLoader($container);
-        $provider->registerModelFactory($container);
-        $provider->registerSourceFactory($container);
-        $provider->registerPropertyFactory($container);
-        $provider->registerModelCollectionLoader($container);
+        $route = $container['model/factory']->get(ObjectRoute::class);
+        if ($route->source()->tableExists() === false) {
+            $route->source()->createTable();
+        }
 
         $this->obj = new News([
             'container'         => $container,
@@ -45,18 +49,17 @@ class NewsTest extends PHPUnit_Framework_TestCase
     public function testSetData()
     {
         $ret = $this->obj->setData([
-            'title'=>'Example title',
-            'subtitle'=>'Subtitle',
-            'content'=>'foobar',
-            'news_date'=>'2015-01-01 20:00:00'
+            'title'     => 'Example title',
+            'subtitle'  => 'Subtitle',
+            'content'   => 'foobar',
+            'news_date' => '2015-01-01 20:00:00'
         ]);
 
         $this->assertSame($ret, $this->obj);
         $this->assertEquals('Example title', (string)$this->obj->title());
         $this->assertEquals('Subtitle', (string)$this->obj->subtitle());
         $this->assertEquals('foobar', (string)$this->obj->content());
-        $this->assertEquals(new DateTime('2015-01-01 20:00:00
-            '), $this->obj->newsDate());
+        $this->assertEquals(new DateTime('2015-01-01 20:00:00'), $this->obj->newsDate());
     }
 
     public function testSetTitle()
@@ -160,33 +163,37 @@ class NewsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Barfoo', (string)$this->obj->metaDescription());
     }
 
-    // public function testMetaImageDefaultsToImage()
-    // {
-    //     $this->assertEquals('', (string)$this->obj->metaImage());
+    /*
+    public function testMetaImageDefaultsToImage()
+    {
+        $this->assertEquals('', (string)$this->obj->metaImage());
 
-    //     $this->obj->setImage('Foo.png');
-    //     $this->assertSame($this->obj->image(), $this->obj->metaImage());
-    //     $this->assertEquals('Foo.png', (string)$this->obj->metaImage());
+        $this->obj->setImage('Foo.png');
+        $this->assertSame($this->obj->image(), $this->obj->metaImage());
+        $this->assertEquals('Foo.png', (string)$this->obj->metaImage());
 
-    //     $this->obj->setMetaImage('Bar.jpg');
-    //     $this->assertEquals('Bar.jpg', (string)$this->obj->metaImage());
-    // }
+        $this->obj->setMetaImage('Bar.jpg');
+        $this->assertEquals('Bar.jpg', (string)$this->obj->metaImage());
+    }
+    */
 
     public function testCategoryType()
     {
         $this->assertEquals(NewsCategory::class, $this->obj->categoryType());
     }
 
+    /*
     public function testSave()
     {
-        //$this->obj->save();
+        $this->obj->save();
     }
+    */
 
     public function testSaveGeneratesSlug()
     {
         $this->assertEquals('', $this->obj->slug());
         $this->obj->setData([
-            'title'=>'foo'
+            'title' => 'foo'
         ]);
         $this->obj->save();
 
@@ -197,7 +204,7 @@ class NewsTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals('', $this->obj->slug());
         $this->obj->setData([
-            'title'=>'foo'
+            'title' => 'foo'
         ]);
         $this->obj->update();
 
@@ -211,9 +218,9 @@ class NewsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', (string)$this->obj->metaImage());
 
         $this->obj->setData([
-            'title'=>'foo',
-            'content'=>'<p>Foo bar</p>',
-            'image' => 'x.jpg'
+            'title'   => 'foo',
+            'content' => '<p>Foo bar</p>',
+            'image'   => 'x.jpg'
         ]);
         $this->obj->save();
 
@@ -229,9 +236,9 @@ class NewsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', (string)$this->obj->metaImage());
 
         $this->obj->setData([
-            'title'=>'foo',
-            'content'=>'<p>Foo bar</p>',
-            'image' => 'x.jpg'
+            'title'   => 'foo',
+            'content' => '<p>Foo bar</p>',
+            'image'   => 'x.jpg'
         ]);
         $this->obj->update();
 

--- a/tests/Charcoal/Cms/Route/NewsRouteTest.php
+++ b/tests/Charcoal/Cms/Route/NewsRouteTest.php
@@ -2,64 +2,52 @@
 
 namespace Charcoal\Tests\Cms\Route;
 
-use \PDO;
+// From PSR-7
+use Psr\Http\Message\RequestInterface;
 
-use \Psr\Log\NullLogger;
-use \Cache\Adapter\Void\VoidCachePool;
+// From Slim
+use Slim\Http\Response;
 
-use \Pimple\Container;
+// From 'charcoal-object'
+use Charcoal\Object\ObjectRoute;
 
-use \Charcoal\Factory\GenericFactory as Factory;
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
 
-use \Charcoal\App\AppConfig;
-
-use \Charcoal\Model\Service\MetadataLoader;
-use \Charcoal\Source\DatabaseSource;
-
-use \Charcoal\Translation\TranslationString;
-
-use \Charcoal\Cms\Route\NewsRoute;
-
-use \Charcoal\Tests\Cms\ContainerProvider;
+// From 'charcoal-cms'
+use Charcoal\Cms\News;
+use Charcoal\Cms\Route\NewsRoute;
 
 /**
  *
  */
 class NewsRouteTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var EventRoute
-     */
-    public $obj;
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
     /**
+     * Tested Class.
      *
+     * @var NewsRoute
+     */
+    private $obj;
+
+    /**
+     * Set up the test.
      */
     public function setUp()
     {
+        $container = $this->getContainer();
+
+        $route = $container['model/factory']->get(ObjectRoute::class);
+        if ($route->source()->tableExists() === false) {
+            $route->source()->createTable();
+        }
+
         $this->obj = new NewsRoute([
             'config' => [],
-            'path' => 'en/news/foo'
+            'path'   => 'en/news/foo'
         ]);
-    }
-
-    /**
-     * @return Container
-     * @see ContainerProvider
-     */
-    private function getContainer()
-    {
-        $provider = new ContainerProvider();
-        $container = new Container();
-
-        $provider->registerBaseServices($container);
-        $provider->registerMetadataLoader($container);
-        $provider->registerSourceFactory($container);
-        $provider->registerPropertyFactory($container);
-        $provider->registerModelFactory($container);
-        $provider->registerModelCollectionLoader($container);
-
-        return $container;
     }
 
     /**
@@ -69,8 +57,11 @@ class NewsRouteTest extends \PHPUnit_Framework_TestCase
     {
         $container = $this->getContainer();
 
+        $locales   = $container['locales/manager'];
+        $locales->setCurrentLocale($locales->currentLocale());
+
         // Create the news table
-        $news = $container['model/factory']->create('charcoal/cms/news');
+        $news = $container['model/factory']->create(News::class);
         $news->source()->createTable();
 
         $ret = $this->obj->pathResolvable($container);
@@ -78,10 +69,10 @@ class NewsRouteTest extends \PHPUnit_Framework_TestCase
 
         // Now try with a resolvable news.
         $news->setData([
-            'id' => 1,
-            'title'=>'Foo',
-            'slug'=>new TranslationString('foo'),
-            'template_ident'=>'bar'
+            'id'             => 1,
+            'title'          => 'Foo',
+            'slug'           => new Translation('foo', $locales),
+            'template_ident' => 'bar'
         ]);
         $id = $news->save();
 
@@ -95,24 +86,11 @@ class NewsRouteTest extends \PHPUnit_Framework_TestCase
     public function testInvoke()
     {
         $container = $this->getContainer();
-        $request = $this->getMock('\Psr\Http\Message\RequestInterface');
-        $response = new \Slim\Http\Response();
-
-
-        $container['template/factory'] = function (Container $container) {
-            return new Factory([
-                'resolver_options' => [
-                    'suffix' => 'Template'
-                ],
-                'arguments' => [[
-                    'container' => $container,
-                    'logger' => $container['logger']
-                ]]
-            ]);
-        };
+        $request   = $this->getMock(RequestInterface::class);
+        $response  = new Response();
 
         // Create the news table
-        $news = $container['model/factory']->create('charcoal/cms/news');
+        $news = $container['model/factory']->create(News::class);
         $news->source()->createTable();
 
         $obj = $this->obj;

--- a/tests/Charcoal/Cms/Route/SectionRouteTest.php
+++ b/tests/Charcoal/Cms/Route/SectionRouteTest.php
@@ -2,64 +2,52 @@
 
 namespace Charcoal\Tests\Cms\Route;
 
-use \PDO;
+// From PSR-7
+use Psr\Http\Message\RequestInterface;
 
-use \Psr\Log\NullLogger;
-use \Cache\Adapter\Void\VoidCachePool;
+// From Slim
+use Slim\Http\Response;
 
-use \Pimple\Container;
+// From 'charcoal-object'
+use Charcoal\Object\ObjectRoute;
 
-use \Charcoal\Factory\GenericFactory as Factory;
+// From 'charcoal-translator'
+use Charcoal\Translator\Translation;
 
-use \Charcoal\App\AppConfig;
-
-use \Charcoal\Model\Service\MetadataLoader;
-use \Charcoal\Source\DatabaseSource;
-
-use \Charcoal\Translation\TranslationString;
-
-use \Charcoal\Cms\Route\SectionRoute;
-
-use \Charcoal\Tests\Cms\ContainerProvider;
+// From 'charcoal-cms'
+use Charcoal\Cms\Section;
+use Charcoal\Cms\Route\SectionRoute;
 
 /**
  *
  */
 class SectionRouteTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var EventRoute
-     */
-    public $obj;
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
     /**
+     * Tested Class.
      *
+     * @var SectionRoute
+     */
+    private $obj;
+
+    /**
+     * Set up the test.
      */
     public function setUp()
     {
+        $container = $this->getContainer();
+
+        $route = $container['model/factory']->get(ObjectRoute::class);
+        if ($route->source()->tableExists() === false) {
+            $route->source()->createTable();
+        }
+
         $this->obj = new SectionRoute([
             'config' => [],
-            'path' => 'en/sections/foo'
+            'path'   => 'en/sections/foo'
         ]);
-    }
-
-    /**
-     * @return Container
-     * @see ContainerProvider
-     */
-    private function getContainer()
-    {
-        $provider = new ContainerProvider();
-        $container = new Container();
-
-        $provider->registerBaseServices($container);
-        $provider->registerMetadataLoader($container);
-        $provider->registerSourceFactory($container);
-        $provider->registerPropertyFactory($container);
-        $provider->registerModelFactory($container);
-        $provider->registerModelCollectionLoader($container);
-
-        return $container;
     }
 
     /**
@@ -69,8 +57,11 @@ class SectionRouteTest extends \PHPUnit_Framework_TestCase
     {
         $container = $this->getContainer();
 
+        $locales   = $container['locales/manager'];
+        $locales->setCurrentLocale($locales->currentLocale());
+
         // Create the section table
-        $section = $container['model/factory']->create('charcoal/cms/section');
+        $section = $container['model/factory']->create(Section::class);
         $section->source()->createTable();
 
         $ret = $this->obj->pathResolvable($container);
@@ -78,10 +69,10 @@ class SectionRouteTest extends \PHPUnit_Framework_TestCase
 
         // Now try with a resolvable section.
         $section->setData([
-            'id' => 1,
-            'title'=>'Foo',
-            'slug'=>new TranslationString('foo'),
-            'template_ident'=>'bar'
+            'id'             => 1,
+            'title'          => 'Foo',
+            'slug'           => new Translation('foo', $locales),
+            'template_ident' => 'bar'
         ]);
         $id = $section->save();
 
@@ -95,24 +86,11 @@ class SectionRouteTest extends \PHPUnit_Framework_TestCase
     public function testInvoke()
     {
         $container = $this->getContainer();
-        $request = $this->getMock('\Psr\Http\Message\RequestInterface');
-        $response = new \Slim\Http\Response();
-
-
-        $container['template/factory'] = function (Container $container) {
-            return new Factory([
-                'resolver_options' => [
-                    'suffix' => 'Template'
-                ],
-                'arguments' => [[
-                    'container' => $container,
-                    'logger' => $container['logger']
-                ]]
-            ]);
-        };
+        $request   = $this->getMock(RequestInterface::class);
+        $response  = new Response();
 
         // Create the section table
-        $section = $container['model/factory']->create('charcoal/cms/section');
+        $section = $container['model/factory']->create(Section::class);
         $section->source()->createTable();
 
         $obj = $this->obj;

--- a/tests/Charcoal/Cms/SectionTest.php
+++ b/tests/Charcoal/Cms/SectionTest.php
@@ -2,35 +2,40 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
+// From 'charcoal-object'
+use Charcoal\Object\ObjectRoute;
 
-use Pimple\Container;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\Section;
-
-use Charcoal\Tests\Cms\ContainerProvider;
 
 /**
  *
  */
-class SectionTest extends PHPUnit_Framework_TestCase
+class SectionTest extends \PHPUnit_Framework_TestCase
 {
-    public $obj;
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
+    /**
+     * Tested Class.
+     *
+     * @var Section
+     */
+    private $obj;
+
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $container = new Container();
-        $provider = new ContainerProvider();
+        $container = $this->getContainer();
 
-        $provider->registerBaseServices($container);
-        $provider->registerMetadataLoader($container);
-        $provider->registerModelFactory($container);
-        $provider->registerSourceFactory($container);
-        $provider->registerPropertyFactory($container);
-        $provider->registerModelCollectionLoader($container);
+        $route = $container['model/factory']->get(ObjectRoute::class);
+        if ($route->source()->tableExists() === false) {
+            $route->source()->createTable();
+        }
 
         $this->obj = new Section([
-             'container'         => $container,
+            'container'         => $container,
             'logger'            => $container['logger'],
             'metadata_loader'   => $container['metadata/loader'],
             'property_factory'  => $container['property/factory'],
@@ -42,14 +47,14 @@ class SectionTest extends PHPUnit_Framework_TestCase
     {
         $obj = $this->obj;
         $ret = $obj->setData([
-            'section_type'  => Section::TYPE_EXTERNAL,
-            'title'         => 'foo',
-            'subtitle'      => 'bar',
-            'content'       => 'baz',
-            'image'         => 'foobar.png',
-            'template_ident' => 'foobar',
+            'section_type'     => Section::TYPE_EXTERNAL,
+            'title'            => 'foo',
+            'subtitle'         => 'bar',
+            'content'          => 'baz',
+            'image'            => 'foobar.png',
+            'template_ident'   => 'foobar',
             'template_options' => [
-                'x'=>'y'
+                'x' => 'y'
             ]
         ]);
         $this->assertSame($ret, $obj);
@@ -60,7 +65,7 @@ class SectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('baz', (string)$obj->content());
         $this->assertEquals('foobar.png', (string)$obj->image());
         $this->assertEquals('foobar', $obj->templateIdent());
-        $this->assertEquals(['x'=>'y'], $obj->templateOptions());
+        $this->assertEquals([ 'x' => 'y' ], $obj->templateOptions());
     }
 
     public function testSetSectionType()
@@ -175,7 +180,7 @@ class SectionTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals('', $this->obj->slug());
         $this->obj->setData([
-            'title'=>'foo'
+            'title' => 'foo'
         ]);
         $this->obj->save();
 
@@ -186,7 +191,7 @@ class SectionTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals('', $this->obj->slug());
         $this->obj->setData([
-            'title'=>'foo'
+            'title' => 'foo'
         ]);
         $this->obj->update();
 
@@ -200,9 +205,9 @@ class SectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', (string)$this->obj->metaImage());
 
         $this->obj->setData([
-            'title'=>'foo',
-            'content'=>'<p>Foo bar</p>',
-            'image' => 'x.jpg'
+            'title'   => 'foo',
+            'content' => '<p>Foo bar</p>',
+            'image'   => 'x.jpg'
         ]);
         $this->obj->save();
 
@@ -218,9 +223,9 @@ class SectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', (string)$this->obj->metaImage());
 
         $this->obj->setData([
-            'title'=>'foo',
-            'content'=>'<p>Foo bar</p>',
-            'image' => 'x.jpg'
+            'title'   => 'foo',
+            'content' => '<p>Foo bar</p>',
+            'image'   => 'x.jpg'
         ]);
         $this->obj->update();
 

--- a/tests/Charcoal/Cms/TextCategoryTest.php
+++ b/tests/Charcoal/Cms/TextCategoryTest.php
@@ -2,36 +2,34 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
-
-use Psr\Log\NullLogger;
-use Cache\Adapter\Void\VoidCachePool;
-
-use Charcoal\Model\Service\MetadataLoader;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\TextCategory;
 use Charcoal\Cms\Text;
 
 /**
  *
  */
-class TextCategoryTest extends PHPUnit_Framework_TestCase
+class TextCategoryTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var TextCategory
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new TextCategory([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container' => $container,
+            'logger'    => $container['logger']
         ]);
     }
 

--- a/tests/Charcoal/Cms/TextTest.php
+++ b/tests/Charcoal/Cms/TextTest.php
@@ -2,44 +2,43 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
-
-use Psr\Log\NullLogger;
-use Cache\Adapter\Void\VoidCachePool;
-
-use Charcoal\Model\Service\MetadataLoader;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\Text;
 use Charcoal\Cms\TextCategory;
 
 /**
  *
  */
-class TextTest extends PHPUnit_Framework_TestCase
+class TextTest extends \PHPUnit_Framework_TestCase
 {
-    public $obj;
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
+    /**
+     * Tested Class.
+     *
+     * @var Text
+     */
+    private $obj;
+
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new Text([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container' => $container,
+            'logger'    => $container['logger']
         ]);
     }
 
     public function testSetData()
     {
         $ret = $this->obj->setData([
-            'title'=>'Example title',
-            'subtitle'=>'Subtitle',
-            'content'=>'foobar'
+            'title'    => 'Example title',
+            'subtitle' => 'Subtitle',
+            'content'  => 'foobar'
         ]);
 
         $this->assertSame($ret, $this->obj);

--- a/tests/Charcoal/Cms/VideoCategoryTest.php
+++ b/tests/Charcoal/Cms/VideoCategoryTest.php
@@ -2,31 +2,34 @@
 
 namespace Charcoal\Cms\Tests;
 
-use \Psr\Log\NullLogger;
-use \Cache\Adapter\Void\VoidCachePool;
-
-use \Charcoal\Model\Service\MetadataLoader;
-
-use \Charcoal\Cms\VideoCategory;
+// From 'charcoal-cms'
+use Charcoal\Cms\VideoCategory;
 use Charcoal\Cms\Video;
 
+/**
+ *
+ */
 class VideoCategoryTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var VideoCategory
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new VideoCategory([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container' => $container,
+            'logger'    => $container['logger']
         ]);
     }
 

--- a/tests/Charcoal/Cms/VideoTest.php
+++ b/tests/Charcoal/Cms/VideoTest.php
@@ -2,46 +2,44 @@
 
 namespace Charcoal\Cms\Tests;
 
-use PHPUnit_Framework_TestCase;
-
-use Psr\Log\NullLogger;
-use Cache\Adapter\Void\VoidCachePool;
-
-use Charcoal\Model\Service\MetadataLoader;
-
+// From 'charcoal-cms'
 use Charcoal\Cms\Video;
 use Charcoal\Cms\VideoCategory;
 
 /**
  *
  */
-class VideoTest extends PHPUnit_Framework_TestCase
+class VideoTest extends \PHPUnit_Framework_TestCase
 {
+    use \Charcoal\Tests\Cms\ContainerIntegrationTrait;
 
-    public $obj;
+    /**
+     * Tested Class.
+     *
+     * @var Video
+     */
+    private $obj;
 
+    /**
+     * Set up the test.
+     */
     public function setUp()
     {
-        $metadataLoader = new MetadataLoader([
-            'logger' => new NullLogger(),
-            'base_path' => __DIR__,
-            'paths' => ['metadata'],
-            'cache'  => new VoidCachePool()
-        ]);
+        $container = $this->getContainer();
 
         $this->obj = new Video([
-            'logger'=> new NullLogger(),
-            'metadata_loader' => $metadataLoader
+            'container' => $container,
+            'logger'    => $container['logger']
         ]);
     }
 
     public function testSetData()
     {
         $ret = $this->obj->setData([
-            'name'=>'foo',
-            'file'=>'foobar',
-            'base_path'=>'baz',
-            'base_url'=>'http://example.com/c'
+            'name'      => 'foo',
+            'file'      => 'foobar',
+            'base_path' => 'baz',
+            'base_url'  => 'http://example.com/c'
         ]);
         $this->assertSame($ret, $this->obj);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,44 +1,6 @@
 <?php
 
-use \Charcoal\App\App;
-use \Charcoal\App\AppConfig;
-use \Charcoal\App\AppContainer;
+date_default_timezone_set('UTC');
 
-// Composer autoloader for Charcoal's psr4-compliant Unit Tests
-$autoloader = require __DIR__.'/../vendor/autoload.php';
-$autoloader->add('Charcoal\\Cms\\', __DIR__.'/../src/');
-$autoloader->add('Charcoal\\Cms\\Tests\\', __DIR__);
-
-$config = new AppConfig([
-    'base_path' => (dirname(__DIR__).'/'),
-    'metadata' => [
-        'paths' => [
-            dirname(__DIR__).'/metadata/'
-        ]
-    ],
-    'translator'=> [
-        'locales'=>[
-            'languages' =>[
-                'en'=>[
-                    'locale'=>'en_US.UTF-8'
-                ]
-            ]
-        ],
-        'translations'=>[
-            'paths'=>[
-
-            ]
-        ]
-    ]
-]);
-$GLOBALS['container'] = new AppContainer([
-    'config' => $config,
-    'cache'  => new \Stash\Pool(),
-    'logger' => new \Psr\Log\NullLogger()
-]);
-
-$GLOBALS['logger'] = new \Psr\Log\NullLogger();
-
-// Charcoal / Slim is the main app
-$GLOBALS['app'] = App::instance($GLOBALS['container']);
-$GLOBALS['app']->setLogger($GLOBALS['logger']);
+/** @var \Composer\Autoload\ClassLoader $autoloader */
+$autoloader = require dirname(__DIR__) . '/vendor/autoload.php';


### PR DESCRIPTION
Changes:
- Replaced ‘charcoal-translation’ with ‘charcoal-translator’;
- Cleaned up class documentation;
- Updated Unit Tests + Cleaned up bootstrap;