### PR TITLE
Update tests: use array access to access instead of methods

### DIFF
--- a/tests/Charcoal/Cms/EventTest.php
+++ b/tests/Charcoal/Cms/EventTest.php
@@ -263,13 +263,13 @@ class EventTest extends AbstractTestCase
      */
     public function testSaveGeneratesSlug()
     {
-        $this->assertEquals('', $this->obj->slug());
+        $this->assertEquals('', $this->obj['slug']);
         $this->obj->setData([
             'title' => 'foo'
         ]);
         $this->obj->save();
 
-        $this->assertEquals('en/events/foo', (string)$this->obj->slug());
+        $this->assertEquals('en/events/foo', (string)$this->obj['slug']);
     }
 
     /**
@@ -277,12 +277,12 @@ class EventTest extends AbstractTestCase
      */
     public function testUpdateGeneratesSlug()
     {
-        $this->assertEquals('', $this->obj->slug());
+        $this->assertEquals('', $this->obj['slug']);
         $this->obj->setData([
             'title' => 'foo'
         ]);
         $this->obj->update();
 
-        $this->assertEquals('en/events/foo', (string)$this->obj->slug());
+        $this->assertEquals('en/events/foo', (string)$this->obj['slug']);
     }
 }

--- a/tests/Charcoal/Cms/NewsTest.php
+++ b/tests/Charcoal/Cms/NewsTest.php
@@ -232,13 +232,13 @@ class NewsTest extends AbstractTestCase
      */
     public function testSaveGeneratesSlug()
     {
-        $this->assertEquals('', $this->obj->slug());
+        $this->assertEquals('', $this->obj['slug']);
         $this->obj->setData([
             'title' => 'foo'
         ]);
         $this->obj->save();
 
-        $this->assertEquals('en/news/foo', (string)$this->obj->slug());
+        $this->assertEquals('en/news/foo', (string)$this->obj['slug']);
     }
 
     /**
@@ -246,12 +246,12 @@ class NewsTest extends AbstractTestCase
      */
     public function testUpdateGeneratesSlug()
     {
-        $this->assertEquals('', $this->obj->slug());
+        $this->assertEquals('', $this->obj['slug']);
         $this->obj->setData([
             'title' => 'foo'
         ]);
         $this->obj->update();
 
-        $this->assertEquals('en/news/foo', (string)$this->obj->slug());
+        $this->assertEquals('en/news/foo', (string)$this->obj['slug']);
     }
 }

--- a/tests/Charcoal/Cms/SectionTest.php
+++ b/tests/Charcoal/Cms/SectionTest.php
@@ -205,13 +205,13 @@ class SectionTest extends AbstractTestCase
      */
     public function testSaveGeneratesSlug()
     {
-        $this->assertEquals('', $this->obj->slug());
+        $this->assertEquals('', $this->obj['slug']);
         $this->obj->setData([
             'title' => 'foo'
         ]);
         $this->obj->save();
 
-        $this->assertEquals('en/foo', (string)$this->obj->slug());
+        $this->assertEquals('en/foo', (string)$this->obj['slug']);
     }
 
     /**
@@ -219,12 +219,12 @@ class SectionTest extends AbstractTestCase
      */
     public function testUpdateGeneratesSlug()
     {
-        $this->assertEquals('', $this->obj->slug());
+        $this->assertEquals('', $this->obj['slug']);
         $this->obj->setData([
             'title' => 'foo'
         ]);
         $this->obj->update();
 
-        $this->assertEquals('en/foo', (string)$this->obj->slug());
+        $this->assertEquals('en/foo', (string)$this->obj['slug']);
     }
 }

--- a/tests/Charcoal/Property/TemplateOptionsPropertyTest.php
+++ b/tests/Charcoal/Property/TemplateOptionsPropertyTest.php
@@ -73,7 +73,7 @@ class TemplateOptionsPropertyTest extends AbstractTestCase
         $return = $this->obj->addStructureInterface($property);
         $this->assertSame($return, $this->obj);
 
-        $interfaces = $this->obj->structureInterfaces();
+        $interfaces = $this->obj['structureInterfaces'];
         $this->assertEquals([ 'charcoal/tests/cms/mocks/generic' ], $interfaces);
     }
 


### PR DESCRIPTION
Update tests: use array access to access the slug in News, Event and Section instead of slug() and use array access to get the structureInterface instead of structureInterfaces() in TemplateOptionsProperty