### PR TITLE
[!] Update to latest Charcoal architecture

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.8.x-dev"
+            "dev-master": "0.9.x-dev"
         }
     },
     "require": {
@@ -27,10 +27,10 @@
         "psr/http-message": "^1.0",
         "locomotivemtl/charcoal-app": "~0.8",
         "locomotivemtl/charcoal-attachment": "~0.10",
-        "locomotivemtl/charcoal-core": "~0.5",
+        "locomotivemtl/charcoal-core": "~0.6",
         "locomotivemtl/charcoal-factory": "~0.4",
         "locomotivemtl/charcoal-object": "~0.7",
-        "locomotivemtl/charcoal-property": "~0.8",
+        "locomotivemtl/charcoal-property": "~0.10",
         "locomotivemtl/charcoal-translator": "~0.3"
     },
     "require-dev": {


### PR DESCRIPTION
Requires:
- locomotivemtl/charcoal-core v0.6.x
- locomotivemtl/charcoal-property v0.10.x

Changed:
- Bump branch-alias to 0.9

Todo:
- [ ] Convert property identifiers to camelCase
- [ ] Prefix property getter methods
- [ ] Normalize "get" prefix in traits (e.g., `DocumentTrait`, `LocaleAwareTrait`)
- [ ] Clean-up `AbstractWebTemplate`
- [ ] Delete new features from PR #9 from original [mcaskill/charcoal-support](https://github.com/mcaskill/charcoal-support)
- [ ] Replace individual metatag methods on `AbstractWebTemplate` with a single Transformer-style method (or one per specification)