### PR TITLE
Fix: traits attachments getters

### DIFF
--- a/src/Charcoal/Cms/Support/Traits/EventManagerAwareTrait.php
+++ b/src/Charcoal/Cms/Support/Traits/EventManagerAwareTrait.php
@@ -273,9 +273,9 @@ trait EventManagerAwareTrait
      */
     protected function eventFormatFull(EventInterface $event)
     {
-        $contentBlocks = $event->attachments('content-blocks');
-        $gallery = $event->attachments('image-gallery');
-        $documents = $event->attachments('document');
+        $contentBlocks = $event->getAttachments('content-blocks');
+        $gallery = $event->getAttachments('image-gallery');
+        $documents = $event->getAttachments('document');
 
         return [
             'id'               => $event->id(),

--- a/src/Charcoal/Cms/Support/Traits/NewsManagerAwareTrait.php
+++ b/src/Charcoal/Cms/Support/Traits/NewsManagerAwareTrait.php
@@ -228,9 +228,9 @@ trait NewsManagerAwareTrait
      */
     protected function newsFormatFull(NewsInterface $news)
     {
-        $contentBlocks = $news->attachments('content-blocks');
-        $gallery = $news->attachments('image-gallery');
-        $documents = $news->attachments('document');
+        $contentBlocks = $news->getAttachments('content-blocks');
+        $gallery = $news->getAttachments('image-gallery');
+        $documents = $news->getAttachments('document');
 
         return [
             'id'               => $news->id(),

--- a/src/Charcoal/Cms/Support/Traits/SectionLoaderAwareTrait.php
+++ b/src/Charcoal/Cms/Support/Traits/SectionLoaderAwareTrait.php
@@ -180,9 +180,9 @@ trait SectionLoaderAwareTrait
      */
     protected function formatSection(SectionInterface $section)
     {
-        $contentBlocks = $section->attachments('content-blocks');
-        $gallery = $section->attachments('image-gallery');
-        $documents = $section->attachments('document');
+        $contentBlocks = $section->getAttachments('content-blocks');
+        $gallery = $section->getAttachments('image-gallery');
+        $documents = $section->getAttachments('document');
 
         return [
             'title'         => (string)$section->title(),


### PR DESCRIPTION
Fix the method to get the attachments of events, news and section in their aware traits.